### PR TITLE
Fix gap limit parse logic

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,11 +1,16 @@
 Package: TestDesign
 Type: Package
 Title: Optimal Test Design Approach to Fixed and Adaptive Test Construction
-Version: 0.2.3
-Date: 2019-08-28
+Version: 0.2.4
+Date: 2019-09-04
 Authors@R: c(
-    person("Seung W.", "Choi", email = "schoi@austin.utexas.edu", role = c("aut", "cre")),
-    person("Sangdon", "Lim", email = "sangdonlim@utexas.edu", role = "aut"))
+    person("Seung W.", "Choi",
+        email = "schoi@austin.utexas.edu",
+        role = c("aut", "cre")),
+    person("Sangdon", "Lim",
+        email = "sangdonlim@utexas.edu",
+        role = "aut",
+        comment = c(ORCID = "0000-0002-2988-014X")))
 Maintainer: Seung W. Choi <schoi@austin.utexas.edu>
 Description: Use the optimal test design approach by Birnbaum (1968, ISBN:9781593119348) and
     van der Linden (2018) <doi:10.1201/9781315117430> in constructing fixed and adaptive tests. Supports the following

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,8 @@ Date: 2019-09-04
 Authors@R: c(
     person("Seung W.", "Choi",
         email = "schoi@austin.utexas.edu",
-        role = c("aut", "cre")),
+        role = c("aut", "cre"),
+        comment = c(ORCID = "0000-0003-4777-5420")),
     person("Sangdon", "Lim",
         email = "sangdonlim@utexas.edu",
         role = "aut",

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@
 * Fix where `time_limit` was not being passed onto `GUROBI` solver in `Shadow()`.
 * Fix where `time_limit` was incorrectly being passed in ms units to `GLPK` solver in `Shadow()`.
 * Fix where a valid interval-based refresh policy was triggering an error in `Shadow()`.
-* Running adaptive assembly with a set-based refresh policy on item pools without sets, now displays a message instead of crashing the Shiny app.
+* Prevent the Shiny app from crashing when running adaptive assembly with a set-based refresh policy on item pools without sets.
 
 ## Others
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * Fix where `gap_limit` was incorrectly being passed onto `SYMPHONY` solver in `ATA()` and `Shadow()`, instead of `gap_limit_abs`. The two gap limits use the same default values, so this should not affect the solutions.
 * Fix where `gap_limit` was not being passed onto `GUROBI` solver in `ATA()` and `Shadow()`.
 * Fix where `time_limit` was not being passed onto `GUROBI` solver in `Shadow()`.
+* Fix where `time_limit` was incorrectly being passed in ms units to `GLPK` solver in `Shadow()`.
 * Fix where a valid interval-based refresh policy was triggering an error in `Shadow()`.
 * Running adaptive assembly with a set-based refresh policy on item pools without sets, now displays a message instead of crashing the Shiny app.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,17 @@
+# TestDesign 0.2.4
+
+## Bug fixes
+
+* Fix where `gap_limit` was incorrectly being passed onto `SYMPHONY` solver in `ATA()` and `Shadow()`, instead of `gap_limit_abs`. The two gap limits use the same default values, so this should not affect the solutions.
+* Fix where `gap_limit` was not being passed onto `GUROBI` solver in `ATA()` and `Shadow()`.
+* Fix where `time_limit` was not being passed onto `GUROBI` solver in `Shadow()`.
+* Fix where a valid interval-based refresh policy was triggering an error in `Shadow()`.
+* Running adaptive assembly with a set-based refresh policy on item pools without sets, now displays a message instead of crashing the Shiny app.
+
+## Others
+
+* Explicitly add `obj_tol` in `config_ATA@MIP` to allow for controlling objective value tolerance.
+
 # TestDesign 0.2.3
 
 ## Bug fixes

--- a/R/ATA_class.R
+++ b/R/ATA_class.R
@@ -23,7 +23,8 @@ setClass("config_ATA",
       verbosity = -2,
       time_limit = 60,
       gap_limit = 0.05,
-      gap_limit_abs = 1
+      gap_limit_abs = 0.05,
+      obj_tol = 0.05
     )
   ),
   validity = function(object) {
@@ -85,8 +86,9 @@ setClass("config_ATA",
 #'   \item{\code{solver}} The type of solver. Accepts \code{SYMPHONY, GUROBI, GLPK, LPSOLVE}.
 #'   \item{\code{verbosity}} Verbosity level of the solver. Defaults to -2.
 #'   \item{\code{time_limit}} Time limit in seconds passed onto the solver. Defaults to 60. Used in solvers \code{SYMPHONY, GUROBI, GLPK}.
-#'   \item{\code{gap_limit}} Termination criteria in relative scale passed onto the solver. Defaults to .05. Used in solvers \code{SYMPHONY, GUROBI}.
-#'   \item{\code{gap_limit_abs}} Termination criteria in absolute scale passed onto the solver. Defaults to 1. Used in solver \code{GUROBI}.
+#'   \item{\code{gap_limit}} Termination criterion. Gap limit in relative scale passed onto the solver. Defaults to .05. Used in solver \code{GUROBI}.
+#'   \item{\code{gap_limit_abs}} Termination criterion. Gap limit in absolute scale passed onto the solver. Defaults to .05. Used in solver \code{SYMPHONY}.
+#'   \item{\code{obj_tol}} Termination criterion. Tolerance on target objective value in absolute difference scale. Defaults to .05. Ignored if method is \code{MAXINFO}.
 #' }
 #'
 #' @examples
@@ -168,5 +170,7 @@ setMethod("show", "config_ATA", function(object) {
   cat("    Solver         :", object@MIP$solver, "\n")
   cat("    Verbosity      :", object@MIP$verbosity, "\n")
   cat("    Time limit     :", object@MIP$time_limit, "\n")
-  cat("    Gap limit      :", object@MIP$gap_limit, "\n\n")
+  cat("    Gap limit      \n")
+  cat("      Relative     :", object@MIP$gap_limit, "\n")
+  cat("      Absolute     :", object@MIP$gap_limit_abs, "\n\n")
 })

--- a/R/runshiny.R
+++ b/R/runshiny.R
@@ -42,7 +42,7 @@ OAT <- function() {
     if (!isNamespaceLoaded("shiny")) {
       attachNamespace("shiny")
     }
-    shiny::runApp(app_dir, display.mode = "normal")
+    shiny::runApp(app_dir, display.mode = "normal", launch.browser = TRUE)
   }
 }
 

--- a/R/shadow_class.R
+++ b/R/shadow_class.R
@@ -155,9 +155,9 @@ setClass("config_Shadow",
     MIP = list(
       solver = "LPSOLVE",
       verbosity = -2,
-      time_limit = -1,
-      gap_limit = NULL,
-      gap_limit_relative = NULL
+      time_limit = 60,
+      gap_limit = .05,
+      gap_limit_abs = .05
     ),
     MCMC = list(
       burn_in = 100,
@@ -289,7 +289,8 @@ setClass("config_Shadow",
 #'   \item{\code{solver}} The type of solver. Accepts one of \code{SYMPHONY, GUROBI, GLPK, LPSOLVE}.
 #'   \item{\code{verbosity}} Verbosity level.
 #'   \item{\code{time_limit}} Time limit to be passed onto solver. Used in solvers \code{SYMPHONY, GUROBI, GLPK}.
-#'   \item{\code{gap_limit}} Gap limit to be passed onto solver. Used in solvers \code{SYMPHONY, GUROBI}.
+#'   \item{\code{gap_limit}} Gap limit (relative) to be passed onto solver. Used in solver \code{GUROBI}. Uses the solver default when \code{NULL}.
+#'   \item{\code{gap_limit_abs}} Gap limit (absolute) to be passed onto solver. Used in solver \code{SYMPHONY}. Uses the solver default when \code{NULL}.
 #' }
 #' @param MCMC A list containing Markov-chain Monte Carlo configurations.
 #' \itemize{
@@ -418,7 +419,8 @@ setMethod("show", "config_Shadow", function(object) {
   cat("    solver          :", object@MIP$solver, "\n")
   cat("    verbosity       :", object@MIP$verbosity, "\n")
   cat("    time_limit      :", object@MIP$time_limit, "\n")
-  cat("    gap_limit       :", object@MIP$gap_limit, "\n\n")
+  cat("    gap_limit       :", object@MIP$gap_limit, "\n")
+  cat("    gap_limit_abs   :", object@MIP$gap_limit_abs, "\n\n")
   cat("  MCMC \n")
   cat("    burn_in         :", object@MCMC$burn_in, "\n")
   cat("    post_burn_in    :", object@MCMC$post_burn_in, "\n")

--- a/R/shadow_class.R
+++ b/R/shadow_class.R
@@ -156,7 +156,8 @@ setClass("config_Shadow",
       solver = "LPSOLVE",
       verbosity = -2,
       time_limit = -1,
-      gap_limit = -1
+      gap_limit = NULL,
+      gap_limit_relative = NULL
     ),
     MCMC = list(
       burn_in = 100,

--- a/R/shadow_functions.R
+++ b/R/shadow_functions.R
@@ -16,8 +16,8 @@ NULL
 #' @param lp Only used when \code{solver} is \code{SYMPHONY}. If \code{TRUE}, print an LP representation of the problem for debugging purposes.
 #' @param verbosity Verbosity level.
 #' @param time_limit Time limit passed onto the solver.
-#' @param gap_limit Gap limit (absolute) passed onto the solver.
-#' @param gap_limit_relative Gap limit (relative) passed onto the solver.
+#' @param gap_limit Gap limit (relative) passed onto the solver. Used in solver \code{GUROBI}.
+#' @param gap_limit_abs Gap limit (absolute) passed onto the solver. Used in solver \code{SYMPHONY}.
 #' @param ... Only used when \code{solver} is \code{SYMPHONY}. Additional parameters to be passed onto the solver.
 #'
 #' @return A list containing the optimal solution and pertinent diagnostics.
@@ -34,7 +34,7 @@ NULL
 #' @export
 
 STA <- function(constraints, objective, solver = "Lpsolve", xmat = NULL, xdir = NULL, xrhs = NULL,
-  maximize = TRUE, mps = FALSE, lp = FALSE, verbosity = -2, time_limit = 5, gap_limit = NULL, gap_limit_relative = NULL, ...) {
+  maximize = TRUE, mps = FALSE, lp = FALSE, verbosity = -2, time_limit = 5, gap_limit = NULL, gap_limit_abs = NULL, ...) {
 
   if (length(objective) == constraints$nv) {
     obj <- objective
@@ -59,8 +59,8 @@ STA <- function(constraints, objective, solver = "Lpsolve", xmat = NULL, xdir = 
 
   if (toupper(solver) == "SYMPHONY") {
 
-    if (!is.null(gap_limit)) {
-      MIP <- Rsymphony::Rsymphony_solve_LP(obj, mat, dir, rhs, max = maximize, types = "B", write_mps = mps, write_lp = lp, verbosity = verbosity, time_limit = time_limit, gap_limit = gap_limit, ...)
+    if (!is.null(gap_limit_abs)) {
+      MIP <- Rsymphony::Rsymphony_solve_LP(obj, mat, dir, rhs, max = maximize, types = "B", write_mps = mps, write_lp = lp, verbosity = verbosity, time_limit = time_limit, gap_limit = gap_limit_abs, ...)
     } else {
       MIP <- Rsymphony::Rsymphony_solve_LP(obj, mat, dir, rhs, max = maximize, types = "B", write_mps = mps, write_lp = lp, verbosity = verbosity, time_limit = time_limit, ...)
     }
@@ -73,10 +73,10 @@ STA <- function(constraints, objective, solver = "Lpsolve", xmat = NULL, xdir = 
   } else if (toupper(solver) == "GUROBI") {
 
     dir[dir == "=="] <- "="
-    if (!is.null(gap_limit_relative)) {
-      invisible(capture.output(MIP <- gurobi::gurobi(list(obj = obj, modelsense = "max", rhs = rhs, sense = dir, vtype = "B", A = mat), params = list(MIPGap = gap_limit_relative), env = NULL)))
+    if (!is.null(gap_limit)) {
+      invisible(capture.output(MIP <- gurobi::gurobi(list(obj = obj, modelsense = "max", rhs = rhs, sense = dir, vtype = "B", A = mat), params = list(MIPGap = gap_limit, TimeLimit = time_limit), env = NULL)))
     } else {
-      invisible(capture.output(MIP <- gurobi::gurobi(list(obj = obj, modelsense = "max", rhs = rhs, sense = dir, vtype = "B", A = mat), env = NULL)))
+      invisible(capture.output(MIP <- gurobi::gurobi(list(obj = obj, modelsense = "max", rhs = rhs, sense = dir, vtype = "B", A = mat), params = list(TimeLimit = time_limit), env = NULL)))
     }
 
     if (!isOptimal(MIP$status, solver)) {
@@ -88,7 +88,7 @@ STA <- function(constraints, objective, solver = "Lpsolve", xmat = NULL, xdir = 
 
   } else if (toupper(solver) == "GLPK") {
 
-    MIP <- Rglpk::Rglpk_solve_LP(obj, mat, dir, rhs, max = maximize, types = "B", control = list(verbose = ifelse(verbosity != -2, TRUE, FALSE), presolve = TRUE, tm_limit = time_limit))
+    MIP <- Rglpk::Rglpk_solve_LP(obj, mat, dir, rhs, max = maximize, types = "B", control = list(verbose = ifelse(verbosity != -2, TRUE, FALSE), presolve = TRUE, tm_limit = time_limit * 1000))
     if (!isOptimal(MIP$status, solver)) {
       warning(sprintf("MIP solver returned non-zero status: %s", MIP$status))
       return(list(status = MIP$status, MIP = MIP, selected = NULL))
@@ -1648,7 +1648,7 @@ setMethod(
 
       } else if (refresh_policy %in% c("INTERVAL", "INTERVAL-THRESHOLD")) {
 
-        if (!(config@refresh_policy$interval >= 1 && config@refresh_policy$interval > test_length)) {
+        if (!(config@refresh_policy$interval >= 1 && config@refresh_policy$interval <= test_length)) {
           stop("config@refresh_policy$interval must be not greater than test length, and be at least 1")
         }
 
@@ -2224,12 +2224,16 @@ setMethod(
                   }
                 }
 
-                optimal <- STA(constraints, info, xmat = rbind(xmat, imat), xdir = c(xdir, idir), xrhs = c(xrhs, irhs), maximize = TRUE, mps = FALSE, lp = FALSE, verbosity = config@MIP$verbosity, time_limit = config@MIP$time_limit, gap_limit = config@MIP$gap_limit, gap_limit_relative = config@MIP$gap_limit_relative, solver = config@MIP$solver)
+                optimal <- STA(constraints, info, xmat = rbind(xmat, imat), xdir = c(xdir, idir), xrhs = c(xrhs, irhs),
+                  maximize = TRUE, mps = FALSE, lp = FALSE, verbosity = config@MIP$verbosity, time_limit = config@MIP$time_limit,
+                  gap_limit = config@MIP$gap_limit, gap_limit_abs = config@MIP$gap_limit_abs, solver = config@MIP$solver)
 
                 is_optimal <- isOptimal(optimal$status, config@MIP$solver)
                 if (!is_optimal) {
                   output@shadow_test_feasible[position] <- FALSE
-                  optimal <- STA(constraints, info, xmat = imat, xdir = idir, xrhs = irhs, maximize = TRUE, mps = FALSE, lp = FALSE, verbosity = config@MIP$verbosity, time_limit = config@MIP$time_limit, gap_limit = config@MIP$gap_limit, gap_limit_relative = config@MIP$gap_limit_relative, solver = config@MIP$solver)
+                  optimal <- STA(constraints, info, xmat = imat, xdir = idir, xrhs = irhs,
+                    maximize = TRUE, mps = FALSE, lp = FALSE, verbosity = config@MIP$verbosity, time_limit = config@MIP$time_limit,
+                    gap_limit = config@MIP$gap_limit, gap_limit_abs = config@MIP$gap_limit_abs, solver = config@MIP$solver)
                 } else {
                   output@shadow_test_feasible[position] <- TRUE
                 }
@@ -2241,12 +2245,16 @@ setMethod(
                 } else {
                   info[item_ineligible == 1] <- -1 * max_info - 1
                 }
-                optimal <- STA(constraints, info, xmat = imat, xdir = idir, xrhs = irhs, maximize = TRUE, mps = FALSE, lp = FALSE, verbosity = config@MIP$verbosity, time_limit = config@MIP$time_limit, gap_limit = config@MIP$gap_limit, gap_limit_relative = config@MIP$gap_limit_relative, solver = config@MIP$solver)
+                optimal <- STA(constraints, info, xmat = imat, xdir = idir, xrhs = irhs,
+                  maximize = TRUE, mps = FALSE, lp = FALSE, verbosity = config@MIP$verbosity, time_limit = config@MIP$time_limit,
+                  gap_limit = config@MIP$gap_limit, gap_limit_abs = config@MIP$gap_limit_abs, solver = config@MIP$solver)
                 output@shadow_test_feasible[position] <- TRUE
 
               }
             } else {
-              optimal <- STA(constraints, info, xmat = imat, xdir = idir, xrhs = irhs, maximize = TRUE, mps = FALSE, lp = FALSE, verbosity = config@MIP$verbosity, time_limit = config@MIP$time_limit, gap_limit = config@MIP$gap_limit, gap_limit_relative = config@MIP$gap_limit_relative, solver = config@MIP$solver)
+              optimal <- STA(constraints, info, xmat = imat, xdir = idir, xrhs = irhs,
+                maximize = TRUE, mps = FALSE, lp = FALSE, verbosity = config@MIP$verbosity, time_limit = config@MIP$time_limit,
+                gap_limit = config@MIP$gap_limit, gap_limit_abs = config@MIP$gap_limit_abs, solver = config@MIP$solver)
               output@shadow_test_feasible[position] <- TRUE
             }
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -18,4 +18,4 @@ Information on obtaining 'gurobi' is described in `DESCRIPTON`.
 
 ## Downstream dependencies
 
-There are no downstream dependencies of the previous version of 'TestDesign' v0.2.2.
+There are no downstream dependencies of the previous version of 'TestDesign' v0.2.3.

--- a/inst/shiny/app.R
+++ b/inst/shiny/app.R
@@ -600,6 +600,8 @@ server <- function(input, output, session) {
         conf@exposure_control$method <- input$exposure_method
         conf@exposure_control$diagnostic_stats <- TRUE
 
+        # parse theta estimation settings
+
         conf@interim_theta$method <- input$interim_method
         conf@interim_theta$prior_dist <- input$interim_prior
         conf@final_theta$method <- input$final_method
@@ -639,7 +641,14 @@ server <- function(input, output, session) {
           }
         }
 
+        # parse refresh policy settings
+
         conf@refresh_policy$method <- input$refresh_policy
+
+        if (conf@refresh_policy$method == "SET" && v$const$set_based == FALSE) {
+          v <- updateLogs(v, "Set-based refresh policy is only applicable for set-based item pools.")
+          break
+        }
 
         if (parseText(input$refresh_interval)) {
           eval(parse(text = sprintf("conf@refresh_policy$interval <- c(%s)[1]", input$refresh_interval)))

--- a/man/STA.Rd
+++ b/man/STA.Rd
@@ -7,7 +7,7 @@
 STA(constraints, objective, solver = "Lpsolve", xmat = NULL,
   xdir = NULL, xrhs = NULL, maximize = TRUE, mps = FALSE,
   lp = FALSE, verbosity = -2, time_limit = 5, gap_limit = NULL,
-  gap_limit_relative = NULL, ...)
+  gap_limit_abs = NULL, ...)
 }
 \arguments{
 \item{constraints}{A list representing optimization constraints. Use \code{\link{loadConstraints}} for this.}
@@ -32,9 +32,9 @@ STA(constraints, objective, solver = "Lpsolve", xmat = NULL,
 
 \item{time_limit}{Time limit passed onto the solver.}
 
-\item{gap_limit}{Gap limit (absolute) passed onto the solver.}
+\item{gap_limit}{Gap limit (relative) passed onto the solver. Used in solver \code{GUROBI}.}
 
-\item{gap_limit_relative}{Gap limit (relative) passed onto the solver.}
+\item{gap_limit_abs}{Gap limit (absolute) passed onto the solver. Used in solver \code{SYMPHONY}.}
 
 \item{...}{Only used when \code{solver} is \code{SYMPHONY}. Additional parameters to be passed onto the solver.}
 }

--- a/man/STA.Rd
+++ b/man/STA.Rd
@@ -6,7 +6,8 @@
 \usage{
 STA(constraints, objective, solver = "Lpsolve", xmat = NULL,
   xdir = NULL, xrhs = NULL, maximize = TRUE, mps = FALSE,
-  lp = FALSE, verbosity = -2, time_limit = 5, gap_limit = -1, ...)
+  lp = FALSE, verbosity = -2, time_limit = 5, gap_limit = NULL,
+  gap_limit_relative = NULL, ...)
 }
 \arguments{
 \item{constraints}{A list representing optimization constraints. Use \code{\link{loadConstraints}} for this.}
@@ -31,7 +32,9 @@ STA(constraints, objective, solver = "Lpsolve", xmat = NULL,
 
 \item{time_limit}{Time limit passed onto the solver.}
 
-\item{gap_limit}{Gap limit passed onto the solver.}
+\item{gap_limit}{Gap limit (absolute) passed onto the solver.}
+
+\item{gap_limit_relative}{Gap limit (relative) passed onto the solver.}
 
 \item{...}{Only used when \code{solver} is \code{SYMPHONY}. Additional parameters to be passed onto the solver.}
 }

--- a/man/createShadowTestConfig.Rd
+++ b/man/createShadowTestConfig.Rd
@@ -31,7 +31,8 @@ createShadowTestConfig(item_selection = NULL, content_balancing = NULL,
   \item{\code{solver}} The type of solver. Accepts one of \code{SYMPHONY, GUROBI, GLPK, LPSOLVE}.
   \item{\code{verbosity}} Verbosity level.
   \item{\code{time_limit}} Time limit to be passed onto solver. Used in solvers \code{SYMPHONY, GUROBI, GLPK}.
-  \item{\code{gap_limit}} Gap limit to be passed onto solver. Used in solvers \code{SYMPHONY, GUROBI}.
+  \item{\code{gap_limit}} Gap limit (relative) to be passed onto solver. Used in solver \code{GUROBI}. Uses the solver default when \code{NULL}.
+  \item{\code{gap_limit_abs}} Gap limit (absolute) to be passed onto solver. Used in solver \code{SYMPHONY}. Uses the solver default when \code{NULL}.
 }}
 
 \item{MCMC}{A list containing Markov-chain Monte Carlo configurations.

--- a/man/createStaticTestConfig.Rd
+++ b/man/createStaticTestConfig.Rd
@@ -23,8 +23,9 @@ createStaticTestConfig(item_selection = NULL, MIP = NULL)
   \item{\code{solver}} The type of solver. Accepts \code{SYMPHONY, GUROBI, GLPK, LPSOLVE}.
   \item{\code{verbosity}} Verbosity level of the solver. Defaults to -2.
   \item{\code{time_limit}} Time limit in seconds passed onto the solver. Defaults to 60. Used in solvers \code{SYMPHONY, GUROBI, GLPK}.
-  \item{\code{gap_limit}} Termination criteria in relative scale passed onto the solver. Defaults to .05. Used in solvers \code{SYMPHONY, GUROBI}.
-  \item{\code{gap_limit_abs}} Termination criteria in absolute scale passed onto the solver. Defaults to 1. Used in solver \code{GUROBI}.
+  \item{\code{gap_limit}} Termination criterion. Gap limit in relative scale passed onto the solver. Defaults to .05. Used in solver \code{GUROBI}.
+  \item{\code{gap_limit_abs}} Termination criterion. Gap limit in absolute scale passed onto the solver. Defaults to .05. Used in solver \code{SYMPHONY}.
+  \item{\code{obj_tol}} Termination criterion. Tolerance on target objective value in absolute difference scale. Defaults to .05. Ignored if method is \code{MAXINFO}.
 }}
 }
 \description{

--- a/vignettes/constraints.Rmd
+++ b/vignettes/constraints.Rmd
@@ -8,7 +8,9 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-## Introduction
+<br/>
+
+### Introduction
 
 This document explains how to create a constraint file. In test assembly, practitioners often want to select the items that satify various types of constraints. As of *TestDesign* version 0.2, constraints can be read in from a `.csv` spreadsheet file. The file is expected to be in the following structure:
 
@@ -34,7 +36,7 @@ knitr::kable(constraints_science_raw[1:5, ]) %>%
 
 The constraint file should have 7 columns, named as `CONSTRAINT`, `TYPE`, `WHAT`, `CONDITION`, `LB`, `UB`, `ONOFF` on the first row of the file. Beginning from the second row, each row should have the corresponding values for the 7 columns. A convenient way to creating the file is to use a spreadsheet application (e.g. Excel), work on the contents from there, and then saving it as a `.csv` file.
 
-\
+<br/>
 
 ***
 
@@ -42,7 +44,7 @@ The constraint file should have 7 columns, named as `CONSTRAINT`, `TYPE`, `WHAT`
 
 This column serves as indices for the constraints. A single numeric value should be put into each row, incrementing by 1.
 
-\
+<br/>
 
 ***
 
@@ -50,7 +52,7 @@ This column serves as indices for the constraints. A single numeric value should
 
 This column specifies the type of constraint. Following values are expected: `Number`, `Order`, `Enemy`, `Include`, `Exclude`, `AllorNone`.
 
-\
+<br/>
 
 * `Number` specifies the constraint to be applied to the number of selected items (if `WHAT` column is `Item`), or to the number of selected item sets (if `WHAT` column is `Stimulus`). For example, the following row tells the solver to select a total of 30 items.
 
@@ -66,8 +68,8 @@ knitr::kable(constraints_science_raw[1, ], row.names = FALSE) %>%
   column_spec(7, "3em")
 ```
 
-\
-\
+<br/>
+<br/>
 
 * `Order` specifies the selection to be made in ascending order. The following row tells the solver to select the items in ascending `LEVEL`, based on the supplied item attributes.
 
@@ -83,8 +85,8 @@ knitr::kable(constraints_science_raw[32, ], row.names = FALSE) %>%
   column_spec(7, "3em")
 ```
 
-\
-\
+<br/>
+<br/>
 
 * `Enemy` specifies the items (or item sets) matching the condition to be treated as enemy items. To tell the solver to select at most one of the two items:
 
@@ -100,8 +102,8 @@ knitr::kable(constraints_science_raw[33, ], row.names = FALSE) %>%
   column_spec(7, "3em")
 ```
 
-\
-\
+<br/>
+<br/>
 
 * `Include` specifies the items matching the condition to be included in selection. For example, the following row tells the solver to include the two items `SC00003` and `SC00004`:
 
@@ -117,8 +119,8 @@ knitr::kable(constraints_science_raw[34, ], row.names = FALSE) %>%
   column_spec(7, "3em")
 ```
 
-\
-\
+<br/>
+<br/>
 
 * `Exclude` specifies the items matching the condition to be excluded in selection. The following row tells the solver to exclude the items satisfying `PTBIS < 0.15`, based on the supplied item attributes.
 
@@ -134,8 +136,8 @@ knitr::kable(constraints_science_raw[35, ], row.names = FALSE) %>%
   column_spec(7, "3em")
 ```
 
-\
-\
+<br/>
+<br/>
 
 * `AllOrNone` specifies the items matching the condition to be either all included or all excluded. To tell the solver to either select the items `SC00005` and `SC00006` at the same time or exclude them at the same time:
 
@@ -151,7 +153,7 @@ knitr::kable(constraints_science_raw[36, ], row.names = FALSE) %>%
   column_spec(7, "3em")
 ```
 
-\
+<br/>
 
 ***
 
@@ -159,7 +161,7 @@ knitr::kable(constraints_science_raw[36, ], row.names = FALSE) %>%
 
 This column specifies where the constraint is applied. The expected values are `Item` or `Stimulus`.
 
-\
+<br/>
 
 ***
 
@@ -188,7 +190,7 @@ knitr::kable(constraints_reading_raw[3, ], row.names = FALSE) %>%
   column_spec(7, "3em")
 ```
 
-\
+<br/>
 
 ***
 
@@ -212,8 +214,8 @@ knitr::kable(constraints_fatigue_raw[1, ], row.names = FALSE) %>%
   column_spec(7, "3em")
 ```
 
-\
-\
+<br/>
+<br/>
 
 * To select 15 to 30 items satisfying `DOK >= 2`:
 
@@ -229,7 +231,7 @@ knitr::kable(constraints_reading_raw[17, ], row.names = FALSE) %>%
   column_spec(7, "3em")
 ```
 
-\
+<br/>
 
 ***
 
@@ -249,3 +251,4 @@ knitr::kable(constraints_reading_raw[18, ], row.names = FALSE) %>%
   column_spec(7, "3em", background = 'cyan')
 ```
 
+<br/>

--- a/vignettes/rsymphony.Rmd
+++ b/vignettes/rsymphony.Rmd
@@ -1,11 +1,17 @@
 ---
 title: "Installing Rsymphony solver package on Mac"
-output: rmarkdown::html_vignette
+output: 
+  html_document: 
+    highlight: null
 vignette: >
   %\VignetteIndexEntry{Installing Rsymphony solver package on Mac}
-  %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
+  %\VignetteEngine{knitr::rmarkdown}
 ---
+
+<br/>
+
+### Introduction
 
 Rsymphony is one of the solver packages supported by TestDesign. As of Rsymphony version 0.1.28, Mac users are likely to encounter error messages like below when the user tries to install the solver package from R.
 
@@ -20,7 +26,10 @@ ERROR: configuration failed for package ‘Rsymphony’
 
 This document describes a potential fix to this problem. An admin account is required.
 
-## Install SYMPHONY libraries
+<br/>
+<br/>
+
+### Install SYMPHONY libraries
 
 The cause of the error is that Rsymphony requires SYMPHONY libraries, but the libraries are not installed. The goal of this section is to install the libraries.
 
@@ -44,7 +53,10 @@ Rsymphony solver package should now be able to locate the SYMPHONY libraries. Re
 
 If the install fails, proceed to the next step.
 
-## Modify the Rsymphony solver package to manually point to SYMPHONY libraries
+<br/>
+<br/>
+
+### Modify the Rsymphony solver package to manually point to SYMPHONY libraries
 
 **Step 1.** Install `wget` by running the following line in terminal. The purpose of this step is to allow downloading the package file directly from CRAN servers.
 
@@ -91,7 +103,10 @@ This will make the Rsymphony solver package available in R.
 
 If the `R CMD` fails with `--lgfortran` error, proceed to the next step.
 
-## Tell R where Fortran libraries are located
+<br/>
+<br/>
+
+### Tell R where Fortran libraries are located
 
 The cause of the error is that R needs Fortran libraries to build the package, but it does not know where they are. They are already available on your system: when you installed the SYMPHONY libraries from the previous steps, it installed gcc library as a requirement, which contains Fortran libraries as well. 
 
@@ -109,7 +124,10 @@ EOF
 sudo R CMD install Rsymphony
 ```
 
-## Resources
+<br/>
+<br/>
+
+### Resources
 
 For further reference, please refer to these following external links.
 


### PR DESCRIPTION
* Fix where `gap_limit` was incorrectly being passed onto `SYMPHONY` solver in `ATA()` and `Shadow()`, instead of `gap_limit_abs`. The two gap limits use the same default values, so this should not affect the solutions.
* Fix where `gap_limit` was not being passed onto `GUROBI` solver in `ATA()` and `Shadow()`.
* Fix where `time_limit` was not being passed onto `GUROBI` solver in `Shadow()`.
* Fix where `time_limit` was incorrectly being passed in ms units to `GLPK` solver in `Shadow()`.
* Fix where a valid interval-based refresh policy was triggering an error in `Shadow()`.
* Prevent the Shiny app from crashing when running adaptive assembly with a set-based refresh policy on item pools without sets.