### PR TITLE
fix roxygenize error when gurobi is installed

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,8 @@ Suggests:
     rmarkdown,
     kableExtra,
     testthat (>= 2.1.0),
-    pkgdown
+    pkgdown,
+    pkgload
 LinkingTo: Rcpp, RcppArmadillo
 RoxygenNote: 7.1.1
 Encoding: UTF-8

--- a/R/import.R
+++ b/R/import.R
@@ -37,24 +37,36 @@ NULL
 
 #' @noRd
 .onAttach <- function(libname, pkgname) {
-  solver_names <- c("lpSolve", "Rsymphony", "lpsymphony", "gurobi", "Rglpk")
 
-  for (s in solver_names) {
-    x <- find.package(s, quiet = TRUE)
-    if (length(x) > 0) {
-      v <- packageVersion(s)
-      e <- testSolver(s)
-      if (e == "") {
-        status <- green("v")
-      } else {
-        status <- yellow("?")
-      }
-    } else {
-      v <- ""
-      status <- red("x")
+  skip_solver_test <- FALSE
+  has_pkgload <- length(find.package("pkgload", quiet = TRUE)) > 0
+  if (has_pkgload) {
+    if (pkgload::is_dev_package("TestDesign")) {
+      # skip if is being loaded by roxygen2
+      # roxygen2 conflicts with gurobi in when running roxygen2::roxygenize
+      skip_solver_test <- TRUE
     }
-    msg <- sprintf("%s %-10s %s %s", status, s, white(sprintf("%-7s", v)), white(e))
-    packageStartupMessage(msg)
+  }
+
+  if (!skip_solver_test) {
+    solver_names <- c("lpSolve", "Rsymphony", "lpsymphony", "gurobi", "Rglpk")
+    for (s in solver_names) {
+      x <- find.package(s, quiet = TRUE)
+      if (length(x) > 0) {
+        v <- packageVersion(s)
+        e <- testSolver(s)
+        if (e == "") {
+          status <- green("v")
+        } else {
+          status <- yellow("?")
+        }
+      } else {
+        v <- ""
+        status <- red("x")
+      }
+      msg <- sprintf("%s %-10s %s %s", status, s, white(sprintf("%-7s", v)), white(e))
+      packageStartupMessage(msg)
+    }
   }
 
   s      <- "TestDesign"

--- a/R/solver_functions.R
+++ b/R/solver_functions.R
@@ -302,20 +302,21 @@ runMIP <- function(solver, obj, mat, dir, rhs, maximize, types,
     constraints_dir <- dir
     constraints_dir[constraints_dir == "=="] <- "="
 
+    if (verbosity <= 0) verbosity <- 0
+    if (verbosity >= 1) verbosity <- 1
+
     if (!is.null(gap_limit)) {
-      tmp <- invisible(capture.output({
-        MIP <- gurobi::gurobi(
-          model = list(obj = obj, modelsense = ifelse(maximize, "max", "min"), rhs = rhs, sense = constraints_dir, vtype = types, A = mat),
-          params = list(MIPGap = gap_limit, TimeLimit = time_limit),
-          env = NULL)
-      }))
+      MIP <- gurobi::gurobi(
+        model = list(obj = obj, modelsense = ifelse(maximize, "max", "min"), rhs = rhs, sense = constraints_dir, vtype = types, A = mat),
+        params = list(MIPGap = gap_limit, TimeLimit = time_limit, LogToConsole = verbosity),
+        env = NULL
+      )
     } else {
-      tmp <- invisible(capture.output({
-        MIP <- gurobi::gurobi(
-          model = list(obj = obj, modelsense = ifelse(maximize, "max", "min"), rhs = rhs, sense = constraints_dir, vtype = types, A = mat),
-          params = list(TimeLimit = time_limit),
-          env = NULL)
-      }))
+      MIP <- gurobi::gurobi(
+        model = list(obj = obj, modelsense = ifelse(maximize, "max", "min"), rhs = rhs, sense = constraints_dir, vtype = types, A = mat),
+        params = list(TimeLimit = time_limit, LogToConsole = verbosity),
+        env = NULL
+      )
     }
 
     MIP[["solution"]] <- MIP$x


### PR DESCRIPTION
- Fix the issue where if `gurobi` is installed, `roxygen2::roxygenize()` fails with the following error:
```
Error in methods::getMethod(name, eval(call$signature), where = env) :
  no method found for function '[' and signature item_pool, numeric
Calls: suppressPackageStartupMessages ... object_from_call -> parser_setMethod -> <Anonymous>
Execution halted
 
Exited with status 1.
```
- Explicitly use the `LogToConsole` parameter in `gurobi` solver calls.
