### PR TITLE
TestDesign 1.2.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: TestDesign
 Type: Package
 Title: Optimal Test Design Approach to Fixed and Adaptive Test Construction
-Version: 1.2.0
-Date: 2021-01-22
+Version: 1.2.1
+Date: 2021-01-24
 Authors@R: c(
     person("Seung W.", "Choi",
         email = "schoi@austin.utexas.edu",

--- a/R/plot_functions.R
+++ b/R/plot_functions.R
@@ -9,7 +9,7 @@ NULL
 #'   \item{\code{\linkS4class{output_Shadow_all}}}: plot audit trail, shadow test chart, and exposure rates from the adaptive assembly solution.
 #'   \item{\code{\linkS4class{output_Shadow}}}: plot audit trail and shadow test chart from the adaptive assembly solution.
 #' }
-#' @param y not used, exists for compatibility with \code{\link[base]{plot}} in the base R package.
+#' @param y not used, exists for compatibility with \code{\link[graphics]{plot}} in the base R package.
 #' @param type the type of plot.
 #' \itemize{
 #'    \item{\code{info} plots information from \code{\linkS4class{item_pool}}, \code{\linkS4class{output_Static}}, and \code{\linkS4class{output_Shadow_all}}.}
@@ -36,7 +36,7 @@ NULL
 #' @param simple used in \code{\linkS4class{output_Shadow}} and \code{\linkS4class{output_Shadow_all}} with \code{type = 'shadow'}. If \code{TRUE}, simplify the chart by hiding unused items.
 #' @param theta_segment used in \code{\linkS4class{output_Shadow_all}} with \code{type = 'exposure'}. The type of theta to determine exposure segments. Accepts \code{Estimated} or \code{True}. (default = \code{Estimated})
 #' @param color_final used in \code{\linkS4class{output_Shadow_all}} with \code{type = 'exposure'}. The color of item-wise exposure rates, only counting the items administered in the final theta segment as exposed.
-#' @param ... arguments to pass onto \code{\link{plot}}.
+#' @param ... arguments to pass onto \code{\link[graphics]{plot}}.
 #'
 #' @examples
 #'

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,4 +1,4 @@
-# TestDesign 1.2.0
+# TestDesign 1.2.1
 
 ## Test environments
 
@@ -6,7 +6,28 @@
 * GitHub Actions:
 * * Windows Server 2019 (R-release)
 * * macOS Catalina 10.15 (R-release)
-* * Ubuntu 20.04 (R-release, R-devel)
+* * Ubuntu 20.04 (R-release, R-devel, R-oldrel)
+
+This version addresses following issues.
+
+* In `man/plot-methods.Rd`, links to `base::plot()` are replaced by links to `graphics::plot()` to resolve a WARNING that occurs in R-oldrel:
+```
+checking Rd cross-references ... WARNING
+Missing link or links in documentation object 'plot-methods.Rd':
+  ‘[base]{plot}’
+```
+The WARNING occurs because `base::plot()` does not exist in versions R 3.x.x.
+
+* In clang-ASAN, gcc-ASAN, the use of 'lpsymphony' in tests was causing heap-buffer-overflow:
+```
+  =================================================================
+  ==3289600==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x62500034f018 at pc 0x000000448067 bp 0x7ffd335f7ee0 sp 0x7ffd335f76a0
+  READ of size 1096 at 0x62500034f018 thread T0
+      #0 0x448066 in memcpy /data/gannet/ripley/Sources2/LLVM/11.0.0/llvm-project-11.0.0/compiler-rt/lib/asan/../sanitizer_common/sanitizer_common_interceptors.inc:808:5
+      #1 0x7fd0a93eac31 in sym_explicit_load_problem(SYM_ENVIRONMENT*, int, int, int*, int*, double*, double*, double*, char*, double*, double*, char*, double*, double*, char) (/lib64/libSym.so.3+0x17c31)
+      #2 0x7fd0a9487394 in lp_symphony_solve /tmp/RtmpHUBnog/R.INSTALL16d35062cfdc66/lpsymphony/src/lp_symphony.cc:47:4
+```
+As a workaround, the use of 'lpsymphony' is replaced with 'lpSolve' in tests.
 
 ## R CMD check results
 
@@ -24,4 +45,4 @@ Information on obtaining 'gurobi' is described in `DESCRIPTION`.
 
 ## Downstream dependencies
 
-The previous version 'TestDesign' 1.1.3 does not have downstream dependencies.
+The previous version 'TestDesign' 1.2.0 does not have downstream dependencies.

--- a/man/plot-methods.Rd
+++ b/man/plot-methods.Rd
@@ -119,7 +119,7 @@
   \item{\code{\linkS4class{output_Shadow}}}: plot audit trail and shadow test chart from the adaptive assembly solution.
 }}
 
-\item{y}{not used, exists for compatibility with \code{\link[base]{plot}} in the base R package.}
+\item{y}{not used, exists for compatibility with \code{\link[graphics]{plot}} in the base R package.}
 
 \item{type}{the type of plot.
 \itemize{
@@ -161,7 +161,7 @@
 
 \item{color_final}{used in \code{\linkS4class{output_Shadow_all}} with \code{type = 'exposure'}. The color of item-wise exposure rates, only counting the items administered in the final theta segment as exposed.}
 
-\item{...}{arguments to pass onto \code{\link{plot}}.}
+\item{...}{arguments to pass onto \code{\link[graphics]{plot}}.}
 }
 \description{
 Extension of plot() for objects in TestDesign package

--- a/tests/testthat/test-gfi.R
+++ b/tests/testthat/test-gfi.R
@@ -1,7 +1,6 @@
 test_that("GFI works", {
 
   skip_on_cran()
-  skip_if_not_installed("lpsymphony")
 
   set.seed(1)
   true_theta <- 0
@@ -18,7 +17,7 @@ test_that("GFI works", {
       method = "BIGM"
     ),
     MIP = list(
-      solver = "LPSYMPHONY"
+      solver = "LPSOLVE"
     )
   )
   set.seed(1)


### PR DESCRIPTION
This version addresses following issues.

* In `man/plot-methods.Rd`, links to `base::plot()` are replaced by links to `graphics::plot()` to resolve a WARNING that occurs in R-oldrel:
```
checking Rd cross-references ... WARNING
Missing link or links in documentation object 'plot-methods.Rd':
  ‘[base]{plot}’
```
The WARNING occurs because `base::plot()` does not exist in versions R 3.x.x.

* In clang-ASAN, gcc-ASAN, the use of 'lpsymphony' in tests was causing heap-buffer-overflow:
```
  =================================================================
  ==3289600==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x62500034f018 at pc 0x000000448067 bp 0x7ffd335f7ee0 sp 0x7ffd335f76a0
  READ of size 1096 at 0x62500034f018 thread T0
      #0 0x448066 in memcpy /data/gannet/ripley/Sources2/LLVM/11.0.0/llvm-project-11.0.0/compiler-rt/lib/asan/../sanitizer_common/sanitizer_common_interceptors.inc:808:5
      #1 0x7fd0a93eac31 in sym_explicit_load_problem(SYM_ENVIRONMENT*, int, int, int*, int*, double*, double*, double*, char*, double*, double*, char*, double*, double*, char) (/lib64/libSym.so.3+0x17c31)
      #2 0x7fd0a9487394 in lp_symphony_solve /tmp/RtmpHUBnog/R.INSTALL16d35062cfdc66/lpsymphony/src/lp_symphony.cc:47:4
```
As a workaround, the use of 'lpsymphony' is replaced with 'lpSolve' in tests.
