### PR TITLE
make plot() more flexible, validate test length constraint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ figures/man.R
 docs
 src/tmp.def
 revdep/
+tests/testthat/Rplots.pdf

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: TestDesign
 Type: Package
 Title: Optimal Test Design Approach to Fixed and Adaptive Test Construction
-Version: 1.2.6.9000
+Version: 1.2.7
 Date: 2021-09-10
 Authors@R: c(
     person("Seung W.", "Choi",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: TestDesign
 Type: Package
 Title: Optimal Test Design Approach to Fixed and Adaptive Test Construction
-Version: 1.2.6
+Version: 1.2.6.9000
 Date: 2021-09-10
 Authors@R: c(
     person("Seung W.", "Choi",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# TestDesign 1.2.7
+
+## Updates
+
+* `plot()` now works better with 'knitr' markdown documents. This is enabled by removing the use of `recordPlot()` inside `plot()`. As a result, `p <- plot()` will not work anymore. Use `recordPlot()` for assigning plots into objects.
+* Shiny app `TestDesign()` is updated to work with the above change.
+* `plot()` gains a new `use_par` argument to override using default graphical parameters that are hard-coded into the function. This allows for more flexible formatting.
+* `theta_segment` argument in `plot(type = "exposure")` is renamed to `theta_type`. The existing argument is deprecated and using it will raise a warning.
+* added validation check for test length constraints. In shadow test approach, test length is expected to be a fixed value.
+
 # TestDesign 1.2.6
 
 ## Updates

--- a/R/constraint_functions.R
+++ b/R/constraint_functions.R
@@ -31,12 +31,17 @@ normalizeConstraintData <- function(x) {
 }
 
 #' @noRd
-validateLBUB <- function(x) {
+validateLBUB <- function(x, allow_range = TRUE) {
   if (any(c(x$LB, x$UB) < 0)) {
       stop(sprintf("constraint %s: LB and UB must be >= 0", x$CONSTRAINT))
     }
   if (x$LB > x$UB) {
     stop(sprintf("constraint %s: LB <= UB must be TRUE", x$CONSTRAINT))
+  }
+  if (!allow_range) {
+    if (x$LB != x$UB) {
+      stop(sprintf("constraint %s: LB == UB must be TRUE for test length", x$CONSTRAINT))
+    }
   }
 }
 
@@ -90,6 +95,7 @@ validateConstraintData <- function(x, attrib) {
     if (
       toupper(x$CONDITION) %in%
       c("", " ", "PER TEST", "TEST")) {
+      validateLBUB(x, allow_range = FALSE)
       return()
     }
 

--- a/R/plot_functions.R
+++ b/R/plot_functions.R
@@ -700,20 +700,14 @@ setMethod(
     }
 
     if (type == "audit") {
-
-      if (!all(examinee_id %in% 1:length(x@output))) {
-        stop("plot(output_Shadow_all): 'examinee_id' out of bounds")
-      }
-      plot(
-        x@output[[examinee_id]],
-        type = "audit",
-        theta_range = theta_range,
-        z_ci = z_ci,
+      plotShadowAudit(
+        x, examinee_id,
+        theta_range,
+        z_ci,
+        use_par,
         ...
       )
-
       return()
-
     } else if (type == "shadow") {
 
       if (!all(examinee_id %in% 1:length(x@output))) {
@@ -1034,6 +1028,24 @@ plotShadowInfo <- function(x, examinee_id, position, info_type, ylim, theta, col
 
   box()
 
+  return()
+
+}
+
+#' @noRd
+plotShadowAudit <- function(x, examinee_id, theta_range, z_ci, use_par, ...) {
+
+  if (!all(examinee_id %in% 1:length(x@output))) {
+    stop("plot(output_Shadow_all): 'examinee_id' out of bounds")
+  }
+  plot(
+    x@output[[examinee_id]],
+    type = "audit",
+    theta_range = theta_range,
+    z_ci = z_ci,
+    use_par = use_par,
+    ...
+  )
   return()
 
 }

--- a/R/plot_functions.R
+++ b/R/plot_functions.R
@@ -737,7 +737,7 @@ setMethod(
 )
 
 #' @noRd
-plotER <- function(
+plotExposurePanel <- function(
   item_exposure_rate, item_exposure_rate_final = NULL,
   stim_exposure_rate = NULL, stim_index = NULL,
   max_rate = max_rate, title = NULL, color = "blue", color_final = "yellow", color_stim = "red", color_threshold = "dark gray", simple = FALSE) {
@@ -1040,7 +1040,7 @@ plotShadowExposure <- function(
 
   for (k in segment) {
     if (k == 0) {
-      plotER(
+      plotExposurePanel(
         item_exposure_rate, item_exposure_rate_final, stim_exposure_rate, x@constraints@stimulus_index_by_item,
         max_rate = max_rate, title = switch(2 - use_segment_label, "Overall", NULL),
         color = color, color_final = color_final, simple = TRUE
@@ -1050,7 +1050,7 @@ plotShadowExposure <- function(
         text(0, 1, sprintf("RMSE = %1.3f", rmse_value), adj = c(0, 1))
       }
     } else {
-      plotER(
+      plotExposurePanel(
         item_exposure_rate_segment[[k]], item_exposure_rate_segment_final[[k]], stim_exposure_rate_segment[[k]], x@constraints@stimulus_index_by_item,
         max_rate = max_rate, title = switch(2 - use_segment_label, segment_label[k], NULL),
         color = color, color_final = color_final, simple = TRUE

--- a/R/plot_functions.R
+++ b/R/plot_functions.R
@@ -740,7 +740,10 @@ setMethod(
 plotExposurePanel <- function(
   item_exposure_rate, item_exposure_rate_final = NULL,
   stim_exposure_rate = NULL, stim_index = NULL,
-  max_rate = max_rate, title = NULL, color = "blue", color_final = "yellow", color_stim = "red", color_threshold = "dark gray", simple = FALSE) {
+  max_rate = max_rate, title = NULL,
+  color = "blue", color_final = "yellow",
+  color_stim = "red", color_threshold = "dark gray",
+  simple = FALSE, ...) {
 
   if (!is.null(stim_index)) {
     idx_sort <- order(stim_exposure_rate, stim_index, item_exposure_rate, decreasing = TRUE)
@@ -762,7 +765,12 @@ plotExposurePanel <- function(
     ylab = ""
   }
 
-  plot(1:ni, item_exposure_rate_ordered, type = "n", lwd = 2, ylim = c(0, 1), xlab = "Item", ylab = "Exposure Rate", main = title)
+  plot(
+    1:ni, item_exposure_rate_ordered,
+    type = "n", lwd = 2, ylim = c(0, 1),
+    xlab = "Item", ylab = "Exposure Rate", main = title,
+    ...
+  )
   points(1:ni, item_exposure_rate_ordered, type = "h", lwd = 1, col = color)
   if (!is.null(stim_exposure_rate)) {
     lines(1:ni, stim_exposure_rate_ordered, col = color_stim, type = "s")
@@ -1043,7 +1051,7 @@ plotShadowExposure <- function(
       plotExposurePanel(
         item_exposure_rate, item_exposure_rate_final, stim_exposure_rate, x@constraints@stimulus_index_by_item,
         max_rate = max_rate, title = switch(2 - use_segment_label, "Overall", NULL),
-        color = color, color_final = color_final, simple = TRUE
+        color = color, color_final = color_final, simple = TRUE, ...
       )
       if (rmse) {
         rmse_value <- sqrt(mean((x@final_theta_est - x@true_theta) ** 2))
@@ -1053,7 +1061,7 @@ plotShadowExposure <- function(
       plotExposurePanel(
         item_exposure_rate_segment[[k]], item_exposure_rate_segment_final[[k]], stim_exposure_rate_segment[[k]], x@constraints@stimulus_index_by_item,
         max_rate = max_rate, title = switch(2 - use_segment_label, segment_label[k], NULL),
-        color = color, color_final = color_final, simple = TRUE
+        color = color, color_final = color_final, simple = TRUE, ...
       )
       if (rmse) {
         rmse_value <- sqrt(mean((x@final_theta_est[theta_segment_index == k] - x@true_theta[theta_segment_index == k]) ** 2))

--- a/R/plot_functions.R
+++ b/R/plot_functions.R
@@ -688,84 +688,15 @@ setMethod(
     }
 
     if (type == "info") {
-
-      o <- x@output[[examinee_id]]
-      if (is.null(position)) {
-        i <- o@administered_item_index
-        txt <- "administered items"
-      } else {
-        i <- o@shadow_test[[position]]$i
-        txt <- sprintf("shadow test at position %s", position)
-      }
-
-      p <- x@pool[i]
-      if (toupper(info_type) == "FISHER") {
-        y <- calcFisher(p, theta)
-        y <- rowSums(y)
-      } else {
-        stop("Invalid info_type specified")
-      }
-
-      if (is.null(ylim)) {
-        ylim <- c(0, max(y))
-      }
-
-      plot(
-        theta, y, xlab = "Theta", ylab = "Information",
-        main = sprintf("Examinee ID: %s (%s)", examinee_id, txt),
-        type = "n", ylim = ylim)
-
-      grid()
-
-      lines(theta, y, col = color)
-
-      legend_label = c()
-      legend_lty   = c()
-      legend_col   = c()
-
-      if (!is.null(o@true_theta)) {
-        abline(v = o@true_theta, col = "red", lty = 1)
-        legend_label <- c(legend_label, sprintf("True theta = %.3f", o@true_theta))
-        legend_lty   <- c(legend_lty, 1)
-        legend_col   <- c(legend_col, "red")
-      }
-
-      abline(v = o@final_theta_est, col = "red", lty = 2)
-      legend_label <- c(legend_label, sprintf("Final theta = %.3f", o@final_theta_est))
-      legend_lty   <- c(legend_lty, 2)
-      legend_col   <- c(legend_col, "red")
-
-      if (!is.null(position)) {
-        abline(v = o@interim_theta_est[position], col = "black", lty = 1)
-        legend_label <- c(legend_label, sprintf("Interim @ %s = %.3f", position, o@interim_theta_est[position]))
-        legend_lty   <- c(legend_lty, 1)
-        legend_col   <- c(legend_col, "black")
-
-        if (position > 1) {
-          abline(v = o@interim_theta_est[position - 1], col = "black", lty = 2)
-          legend_label <- c(legend_label, sprintf("Interim @ %s = %.3f", position - 1, o@interim_theta_est[position - 1]))
-          legend_lty   <- c(legend_lty, 2)
-          legend_col   <- c(legend_col, "black")
-        }
-        if (position == 1) {
-          abline(v = o@initial_theta_est, col = "black", lty = 2)
-          legend_label <- c(legend_label, sprintf("Initial theta = %.3f", o@initial_theta_est))
-          legend_lty   <- c(legend_lty, 2)
-          legend_col   <- c(legend_col, "black")
-        }
-      }
-
-      legend(
-        "topleft",
-        legend = legend_label,
-        lty    = legend_lty,
-        col    = legend_col
+      plotShadowInfo(
+        x, examinee_id, position,
+        info_type,
+        ylim, theta,
+        color,
+        use_par,
+        ...
       )
-
-      box()
-
       return()
-
     }
 
     if (type == "audit") {
@@ -1023,4 +954,86 @@ plotER <- function(
     item_exposure_rate_final_ordered <- item_exposure_rate_final[idx_sort]
     points(1:ni, item_exposure_rate_final_ordered, type = "h", lwd = 1, lty = 1, col = color_final)
   }
+}
+
+#' @noRd
+plotShadowInfo <- function(x, examinee_id, position, info_type, ylim, theta, color, use_par, ...) {
+
+  o <- x@output[[examinee_id]]
+  if (is.null(position)) {
+    i <- o@administered_item_index
+    txt <- "administered items"
+  } else {
+    i <- o@shadow_test[[position]]$i
+    txt <- sprintf("shadow test at position %s", position)
+  }
+
+  p <- x@pool[i]
+  if (toupper(info_type) == "FISHER") {
+    y <- calcFisher(p, theta)
+    y <- rowSums(y)
+  } else {
+    stop("Invalid info_type specified")
+  }
+
+  if (is.null(ylim)) {
+    ylim <- c(0, max(y))
+  }
+
+  plot(
+    theta, y, xlab = "Theta", ylab = "Information",
+    main = sprintf("Examinee ID: %s (%s)", examinee_id, txt),
+    type = "n", ylim = ylim)
+
+  grid()
+
+  lines(theta, y, col = color)
+
+  legend_label = c()
+  legend_lty   = c()
+  legend_col   = c()
+
+  if (!is.null(o@true_theta)) {
+    abline(v = o@true_theta, col = "red", lty = 1)
+    legend_label <- c(legend_label, sprintf("True theta = %.3f", o@true_theta))
+    legend_lty   <- c(legend_lty, 1)
+    legend_col   <- c(legend_col, "red")
+  }
+
+  abline(v = o@final_theta_est, col = "red", lty = 2)
+  legend_label <- c(legend_label, sprintf("Final theta = %.3f", o@final_theta_est))
+  legend_lty   <- c(legend_lty, 2)
+  legend_col   <- c(legend_col, "red")
+
+  if (!is.null(position)) {
+    abline(v = o@interim_theta_est[position], col = "black", lty = 1)
+    legend_label <- c(legend_label, sprintf("Interim @ %s = %.3f", position, o@interim_theta_est[position]))
+    legend_lty   <- c(legend_lty, 1)
+    legend_col   <- c(legend_col, "black")
+
+    if (position > 1) {
+      abline(v = o@interim_theta_est[position - 1], col = "black", lty = 2)
+      legend_label <- c(legend_label, sprintf("Interim @ %s = %.3f", position - 1, o@interim_theta_est[position - 1]))
+      legend_lty   <- c(legend_lty, 2)
+      legend_col   <- c(legend_col, "black")
+    }
+    if (position == 1) {
+      abline(v = o@initial_theta_est, col = "black", lty = 2)
+      legend_label <- c(legend_label, sprintf("Initial theta = %.3f", o@initial_theta_est))
+      legend_lty   <- c(legend_lty, 2)
+      legend_col   <- c(legend_col, "black")
+    }
+  }
+
+  legend(
+    "topleft",
+    legend = legend_label,
+    lty    = legend_lty,
+    col    = legend_col
+  )
+
+  box()
+
+  return()
+
 }

--- a/R/plot_functions.R
+++ b/R/plot_functions.R
@@ -39,6 +39,7 @@ NULL
 #' @param segment used in \code{\linkS4class{output_Shadow_all}} with \code{type = 'exposure'}. (optional) The segment index to draw the plot. Leave empty to use all segments.
 #' @param rmse used in \code{\linkS4class{output_Shadow_all}} with \code{type = 'exposure'}. If \code{TRUE}, display the RMSE value for each segment. (default = \code{FALSE})
 #' @param use_segment_label used in \code{\linkS4class{output_Shadow_all}} with \code{type = 'exposure'}. If \code{TRUE}, display the segment label for each segment. (default = \code{TRUE})
+#' @param use_par if \code{FALSE}, graphical parameters are not overridden inside the function. (default = \code{TRUE})
 #' @param ... arguments to pass onto \code{\link[graphics]{plot}}.
 #'
 #' @examples
@@ -95,6 +96,7 @@ setMethod(
     segment = NULL,
     rmse = FALSE,
     use_segment_label = TRUE,
+    use_par = TRUE,
     ...) {
 
     if (!is.null(select)) {
@@ -173,6 +175,7 @@ setMethod(
     segment = NULL,
     rmse = FALSE,
     use_segment_label = TRUE,
+    use_par = TRUE,
     ...) {
 
     config      <- x@config
@@ -278,6 +281,7 @@ setMethod(
     theta_segment = "Estimated",
     color_final = "blue",
     segment = NULL,
+    use_par = TRUE,
     ...) {
 
     if (!type == "info") {
@@ -341,18 +345,22 @@ setMethod(
     segment = NULL,
     rmse = FALSE,
     use_segment_label = TRUE,
+    use_par = TRUE,
     ...) {
 
     if (type == "audit") {
+
+      if (use_par) {
+        old_par <- par(no.readonly = TRUE)
+        on.exit({
+          par(old_par)
+        })
+        par(mar = c(2, 3, 1, 1) + 0.1)
+      }
+
       n_items <- length(x@administered_item_index)
       min_theta <- theta_range[1]
       max_theta <- theta_range[2]
-
-      old_par <- par(no.readonly = TRUE)
-      on.exit({
-        par(old_par)
-      })
-      par(mar = c(2, 3, 1, 1) + 0.1)
 
       layout(rbind(c(1, 1), c(1, 1), c(1, 1), c(1, 1), c(2, 2)))
 
@@ -421,14 +429,16 @@ setMethod(
 
     if (type == "shadow") {
 
+      if (use_par) {
+        old_par <- par(no.readonly = TRUE)
+        on.exit({
+          par(old_par)
+        })
+        par(mar = c(2, 3, 1, 1) + 0.1, mfrow = c(1, 1))
+      }
+
       test_length  <- x@test_length_constraints
       ni_pool      <- x@ni_pool
-
-      old_par <- par(no.readonly = TRUE)
-      on.exit({
-        par(old_par)
-      })
-      par(mar = c(2, 3, 1, 1) + 0.1, mfrow = c(1, 1))
 
       max_position <- sum(!is.na(x@administered_item_resp))
 
@@ -670,6 +680,7 @@ setMethod(
     segment = NULL,
     rmse = FALSE,
     use_segment_label = TRUE,
+    use_par = TRUE,
     ...) {
 
     if (!type %in% c("audit", "shadow", "info", "score", "exposure")) {
@@ -903,16 +914,18 @@ setMethod(
         stim_exposure_rate_segment_final <- NULL
       }
 
-      if (is.null(segment)) {
-
-        segment <- c(0, 1:n_segment)
-        use_axis_labels <- TRUE
-
+      if (use_par) {
         old_par <- par(no.readonly = TRUE)
         on.exit({
           par(old_par)
         })
         par(oma = c(3, 3, 0, 0), mar = c(3, 3, 2, 2))
+      }
+
+      if (is.null(segment)) {
+
+        segment <- c(0, 1:n_segment)
+        use_axis_labels <- TRUE
 
       } else {
 

--- a/R/plot_functions.R
+++ b/R/plot_functions.R
@@ -1000,3 +1000,47 @@ setMethod(
     }
   }
 )
+
+#' @noRd
+plotER <- function(
+  item_exposure_rate, item_exposure_rate_final = NULL,
+  stim_exposure_rate = NULL, stim_index = NULL,
+  max_rate = max_rate, title = NULL, color = "blue", color_final = "yellow", color_stim = "red", color_threshold = "dark gray", simple = FALSE) {
+
+  if (!is.null(stim_index)) {
+    idx_sort <- order(stim_exposure_rate, stim_index, item_exposure_rate, decreasing = TRUE)
+    item_exposure_rate_ordered <- item_exposure_rate[idx_sort]
+    stim_exposure_rate_ordered <- stim_exposure_rate[idx_sort]
+    stim_index_ordered         <- stim_index[idx_sort]
+  } else {
+    idx_sort <- order(item_exposure_rate, decreasing = TRUE)
+    item_exposure_rate_ordered <- item_exposure_rate[idx_sort]
+  }
+
+  ni <- length(item_exposure_rate)
+
+  if (!simple) {
+    xlab = "Item"
+    ylab = "Exposure Rate"
+  } else {
+    xlab = ""
+    ylab = ""
+  }
+
+  plot(1:ni, item_exposure_rate_ordered, type = "n", lwd = 2, ylim = c(0, 1), xlab = "Item", ylab = "Exposure Rate", main = title)
+  points(1:ni, item_exposure_rate_ordered, type = "h", lwd = 1, col = color)
+  if (!is.null(stim_exposure_rate)) {
+    lines(1:ni, stim_exposure_rate_ordered, col = color_stim, type = "s")
+    for (stim_id in unique(stim_index_ordered)) {
+      x <- mean((1:ni)[which(stim_index_ordered == stim_id)])
+      y <- stim_exposure_rate_ordered[which(stim_index_ordered == stim_id)][1]
+      points(x, y, col = color_stim, pch = 21, bg = 'white', cex = .75)
+    }
+  }
+  abline(h = max_rate, col = color_threshold, lty = 2)
+
+  if (!is.null(item_exposure_rate_final)) {
+    item_exposure_rate_final_ordered <- item_exposure_rate_final[idx_sort]
+    points(1:ni, item_exposure_rate_final_ordered, type = "h", lwd = 1, lty = 1, col = color_final)
+  }
+}

--- a/R/plot_functions.R
+++ b/R/plot_functions.R
@@ -171,11 +171,6 @@ setMethod(
     color = "blue",
     z_ci = 1.96,
     simple = TRUE,
-    theta_type = "Estimated",
-    color_final = "blue",
-    segment = NULL,
-    rmse = FALSE,
-    use_segment_label = TRUE,
     use_par = TRUE,
     ...) {
 
@@ -279,9 +274,6 @@ setMethod(
     color = "blue",
     z_ci = 1.96,
     simple = TRUE,
-    theta_type = "Estimated",
-    color_final = "blue",
-    segment = NULL,
     use_par = TRUE,
     ...) {
 
@@ -342,10 +334,6 @@ setMethod(
     z_ci = 1.96,
     simple = FALSE,
     theta_type = "Estimated",
-    color_final = "blue",
-    segment = NULL,
-    rmse = FALSE,
-    use_segment_label = TRUE,
     use_par = TRUE,
     ...) {
 

--- a/R/plot_functions.R
+++ b/R/plot_functions.R
@@ -708,20 +708,16 @@ setMethod(
         ...
       )
       return()
-    } else if (type == "shadow") {
+    }
 
-      if (!all(examinee_id %in% 1:length(x@output))) {
-        stop("plot(output_Shadow_all): 'examinee_id' out of bounds")
-      }
-      plot(
-        x@output[[examinee_id]],
-        type = "shadow",
-        simple = simple,
+    if (type == "shadow") {
+      plotShadowChart(
+        x, examinee_id,
+        simple,
+        use_par,
         ...
       )
-
       return()
-
     } else if (type == "exposure") {
 
       if (toupper(theta_segment) == "TRUE") {
@@ -1046,6 +1042,24 @@ plotShadowAudit <- function(x, examinee_id, theta_range, z_ci, use_par, ...) {
     use_par = use_par,
     ...
   )
+  return()
+
+}
+
+#' @noRd
+plotShadowChart <- function(x, examinee_id, simple, use_par, ...) {
+
+  if (!all(examinee_id %in% 1:length(x@output))) {
+    stop("plot(output_Shadow_all): 'examinee_id' out of bounds")
+  }
+  plot(
+    x@output[[examinee_id]],
+    type = "shadow",
+    simple = simple,
+    use_par = use_par,
+    ...
+  )
+
   return()
 
 }

--- a/R/plot_functions.R
+++ b/R/plot_functions.R
@@ -144,9 +144,7 @@ setMethod(
 
     box()
 
-    p <- recordPlot()
-    dev.off()
-    return(p)
+    return()
 
   }
 )
@@ -253,9 +251,7 @@ setMethod(
 
     box()
 
-    p <- recordPlot()
-    dev.off()
-    return(p)
+    return()
 
   }
 )
@@ -317,9 +313,7 @@ setMethod(
 
     box()
 
-    p <- recordPlot()
-    dev.off()
-    return(p)
+    return()
 
   }
 )
@@ -354,14 +348,9 @@ setMethod(
       min_theta <- theta_range[1]
       max_theta <- theta_range[2]
 
-      old_mar   <- par()$mar
-      old_mfrow <- par()$mfrow
+      old_par <- par(no.readonly = TRUE)
       on.exit({
-        close_dev <- ifelse(dev.cur() == 1, TRUE, FALSE)
-        par(mar = old_mar, mfrow = old_mfrow)
-        if (close_dev) {
-          dev.off()
-        }
+        par(old_par)
       })
       par(mar = c(2, 3, 1, 1) + 0.1)
 
@@ -426,10 +415,7 @@ setMethod(
 
       }
 
-      par(mar = old_mar, mfrow = old_mfrow)
-      p <- recordPlot()
-      dev.off()
-      return(p)
+      return()
 
     }
 
@@ -438,14 +424,9 @@ setMethod(
       test_length  <- x@test_length_constraints
       ni_pool      <- x@ni_pool
 
-      old_mar   <- par()$mar
-      old_mfrow <- par()$mfrow
+      old_par <- par(no.readonly = TRUE)
       on.exit({
-        close_dev <- ifelse(dev.cur() == 1, TRUE, FALSE)
-        par(mar = old_mar, mfrow = old_mfrow)
-        if (close_dev) {
-          dev.off()
-        }
+        par(old_par)
       })
       par(mar = c(2, 3, 1, 1) + 0.1, mfrow = c(1, 1))
 
@@ -658,10 +639,7 @@ setMethod(
 
       }
 
-      par(mar = old_mar, mfrow = old_mfrow)
-      p <- recordPlot()
-      dev.off()
-      return(p)
+      return()
 
     }
 
@@ -775,9 +753,7 @@ setMethod(
 
       box()
 
-      p <- recordPlot()
-      dev.off()
-      return(p)
+      return()
 
     }
 
@@ -786,7 +762,7 @@ setMethod(
       if (!all(examinee_id %in% 1:length(x@output))) {
         stop("plot(output_Shadow_all): 'examinee_id' out of bounds")
       }
-      p <- plot(
+      plot(
         x@output[[examinee_id]],
         type = "audit",
         theta_range = theta_range,
@@ -794,21 +770,21 @@ setMethod(
         ...
       )
 
-      return(p)
+      return()
 
     } else if (type == "shadow") {
 
       if (!all(examinee_id %in% 1:length(x@output))) {
         stop("plot(output_Shadow_all): 'examinee_id' out of bounds")
       }
-      p <- plot(
+      plot(
         x@output[[examinee_id]],
         type = "shadow",
         simple = simple,
         ...
       )
 
-      return(p)
+      return()
 
     } else if (type == "exposure") {
 
@@ -932,14 +908,9 @@ setMethod(
         segment <- c(0, 1:n_segment)
         use_axis_labels <- TRUE
 
-        old_oma <- par()$oma
-        old_mar <- par()$mar
+        old_par <- par(no.readonly = TRUE)
         on.exit({
-          close_dev <- ifelse(dev.cur() == 1, TRUE, FALSE)
-          par(oma = old_oma, mar = old_mar)
-          if (close_dev) {
-            dev.off()
-          }
+          par(old_par)
         })
         par(oma = c(3, 3, 0, 0), mar = c(3, 3, 2, 2))
 
@@ -976,14 +947,10 @@ setMethod(
       if (use_axis_labels) {
         mtext(text = "Item"         , side = 1, line = 0, outer = TRUE)
         mtext(text = "Exposure Rate", side = 2, line = 0, outer = TRUE)
-        par(oma = old_oma, mar = old_mar)
       }
 
-      p <- recordPlot()
-      dev.off()
-
       out <- new("exposure_rate_plot")
-      out@plot <- p
+      out@plot <- NULL
       out@item_exposure_rate         <- item_exposure_rate
       out@item_exposure_rate_segment <- item_exposure_rate_segment
       out@item_exposure_rate_segment_final <- item_exposure_rate_segment_final

--- a/R/plot_functions.R
+++ b/R/plot_functions.R
@@ -34,12 +34,13 @@ NULL
 #' @param ylim (optional) the y-axis plot range. Used in most plot types.
 #' @param z_ci used in \code{\linkS4class{output_Shadow}} and \code{\linkS4class{output_Shadow_all}} with \code{type = 'audit'}. The range to use for confidence intervals. (default = \code{1.96})
 #' @param simple used in \code{\linkS4class{output_Shadow}} and \code{\linkS4class{output_Shadow_all}} with \code{type = 'shadow'}. If \code{TRUE}, simplify the chart by hiding unused items.
-#' @param theta_segment used in \code{\linkS4class{output_Shadow_all}} with \code{type = 'exposure'}. The type of theta to determine exposure segments. Accepts \code{Estimated} or \code{True}. (default = \code{Estimated})
+#' @param theta_type used in \code{\linkS4class{output_Shadow_all}} with \code{type = 'exposure'}. The type of theta to determine exposure segments. Accepts \code{Estimated} or \code{True}. (default = \code{Estimated})
 #' @param color_final used in \code{\linkS4class{output_Shadow_all}} with \code{type = 'exposure'}. The color of item-wise exposure rates, only counting the items administered in the final theta segment as exposed.
 #' @param segment used in \code{\linkS4class{output_Shadow_all}} with \code{type = 'exposure'}. (optional) The segment index to draw the plot. Leave empty to use all segments.
 #' @param rmse used in \code{\linkS4class{output_Shadow_all}} with \code{type = 'exposure'}. If \code{TRUE}, display the RMSE value for each segment. (default = \code{FALSE})
 #' @param use_segment_label used in \code{\linkS4class{output_Shadow_all}} with \code{type = 'exposure'}. If \code{TRUE}, display the segment label for each segment. (default = \code{TRUE})
 #' @param use_par if \code{FALSE}, graphical parameters are not overridden inside the function. (default = \code{TRUE})
+#' @param theta_segment (deprecated) use \code{theta_type} argument instead.
 #' @param ... arguments to pass onto \code{\link[graphics]{plot}}.
 #'
 #' @examples
@@ -91,7 +92,7 @@ setMethod(
     color = "blue",
     z_ci = 1.96,
     simple = TRUE,
-    theta_segment = "Estimated",
+    theta_type = "Estimated",
     color_final = "blue",
     segment = NULL,
     rmse = FALSE,
@@ -170,7 +171,7 @@ setMethod(
     color = "blue",
     z_ci = 1.96,
     simple = TRUE,
-    theta_segment = "Estimated",
+    theta_type = "Estimated",
     color_final = "blue",
     segment = NULL,
     rmse = FALSE,
@@ -278,7 +279,7 @@ setMethod(
     color = "blue",
     z_ci = 1.96,
     simple = TRUE,
-    theta_segment = "Estimated",
+    theta_type = "Estimated",
     color_final = "blue",
     segment = NULL,
     use_par = TRUE,
@@ -340,7 +341,7 @@ setMethod(
     color = "blue",
     z_ci = 1.96,
     simple = FALSE,
-    theta_segment = "Estimated",
+    theta_type = "Estimated",
     color_final = "blue",
     segment = NULL,
     rmse = FALSE,
@@ -675,14 +676,19 @@ setMethod(
     color = "blue",
     z_ci = 1.96,
     simple = FALSE,
-    theta_segment = "Estimated",
+    theta_type = "Estimated",
     color_final = "blue",
     segment = NULL,
     rmse = FALSE,
     use_segment_label = TRUE,
     use_par = TRUE,
+    theta_segment = NULL,
     ...) {
 
+    if (!missing("theta_segment")){
+      warning("argument 'theta_segment' is deprecated. Use 'theta_type' instead.")
+      theta_type <- theta_segment
+    }
     if (!type %in% c("audit", "shadow", "info", "score", "exposure")) {
       stop("plot(output_Shadow_all): 'type' must be 'audit', 'shadow', 'info', 'score', or 'exposure'")
     }
@@ -722,7 +728,7 @@ setMethod(
 
     if (type == "exposure") {
       plotShadowExposure(
-        x, theta_segment,
+        x, theta_type,
         segment,
         use_segment_label,
         color, color_final,
@@ -908,18 +914,18 @@ plotShadowChart <- function(x, examinee_id, simple, use_par, ...) {
 
 #' @noRd
 plotShadowExposure <- function(
-  x, theta_segment,
+  x, theta_type,
   segment, use_segment_label,
   color, color_final, rmse, use_par, ...) {
 
-  if (toupper(theta_segment) == "TRUE") {
+  if (toupper(theta_type) == "TRUE") {
     theta_value <- x@true_theta
     nj          <- length(theta_value)
-  } else if (toupper(theta_segment) == "ESTIMATED") {
+  } else if (toupper(theta_type) == "ESTIMATED") {
     theta_value <- x@final_theta_est
     nj          <- length(theta_value)
   } else {
-    stop("plot(output_Shadow_all): 'theta_segment' must be 'estimated' or 'true'")
+    stop("plot(output_Shadow_all): 'theta_type' must be 'estimated' or 'true'")
   }
 
   ni <- x@pool@ni

--- a/R/plot_functions.R
+++ b/R/plot_functions.R
@@ -147,7 +147,7 @@ setMethod(
 
     box()
 
-    return()
+    return(invisible(NULL))
 
   }
 )
@@ -250,7 +250,7 @@ setMethod(
 
     box()
 
-    return()
+    return(invisible(NULL))
 
   }
 )
@@ -310,7 +310,7 @@ setMethod(
 
     box()
 
-    return()
+    return(invisible(NULL))
 
   }
 )
@@ -412,7 +412,7 @@ setMethod(
 
       }
 
-      return()
+      return(invisible(NULL))
 
     }
 
@@ -638,7 +638,7 @@ setMethod(
 
       }
 
-      return()
+      return(invisible(NULL))
 
     }
 
@@ -690,7 +690,7 @@ setMethod(
         use_par,
         ...
       )
-      return()
+      return(invisible(NULL))
     }
 
     if (type == "audit") {
@@ -701,7 +701,7 @@ setMethod(
         use_par,
         ...
       )
-      return()
+      return(invisible(NULL))
     }
 
     if (type == "shadow") {
@@ -711,7 +711,7 @@ setMethod(
         use_par,
         ...
       )
-      return()
+      return(invisible(NULL))
     }
 
     if (type == "exposure") {
@@ -724,7 +724,7 @@ setMethod(
         use_par,
         ...
       )
-      return()
+      return(invisible(NULL))
     }
 
   }
@@ -860,7 +860,7 @@ plotShadowInfo <- function(x, examinee_id, position, info_type, ylim, theta, col
 
   box()
 
-  return()
+  return(invisible(NULL))
 
 }
 
@@ -878,7 +878,7 @@ plotShadowAudit <- function(x, examinee_id, theta_range, z_ci, use_par, ...) {
     use_par = use_par,
     ...
   )
-  return()
+  return(invisible(NULL))
 
 }
 
@@ -896,7 +896,7 @@ plotShadowChart <- function(x, examinee_id, simple, use_par, ...) {
     ...
   )
 
-  return()
+  return(invisible(NULL))
 
 }
 

--- a/R/print_functions.R
+++ b/R/print_functions.R
@@ -358,7 +358,6 @@ setMethod("print", "output_Shadow_all", function(x) {
 #' @docType methods
 #' @rdname print-methods
 setMethod("print", "exposure_rate_plot", function(x) {
-  print(x@plot)
   return(invisible(x))
 })
 

--- a/R/shadow_functions.R
+++ b/R/shadow_functions.R
@@ -660,49 +660,6 @@ checkConstraints <- function(constraints, usage_matrix, true_theta = NULL) {
     groupHIT = groupHIT[numberIndex, ]))
 }
 
-#' @noRd
-plotER <- function(
-  item_exposure_rate, item_exposure_rate_final = NULL,
-  stim_exposure_rate = NULL, stim_index = NULL,
-  max_rate = max_rate, title = NULL, color = "blue", color_final = "yellow", color_stim = "red", color_threshold = "dark gray", simple = FALSE) {
-
-  if (!is.null(stim_index)) {
-    idx_sort <- order(stim_exposure_rate, stim_index, item_exposure_rate, decreasing = TRUE)
-    item_exposure_rate_ordered <- item_exposure_rate[idx_sort]
-    stim_exposure_rate_ordered <- stim_exposure_rate[idx_sort]
-    stim_index_ordered         <- stim_index[idx_sort]
-  } else {
-    idx_sort <- order(item_exposure_rate, decreasing = TRUE)
-    item_exposure_rate_ordered <- item_exposure_rate[idx_sort]
-  }
-
-  ni <- length(item_exposure_rate)
-
-  if (!simple) {
-    xlab = "Item"
-    ylab = "Exposure Rate"
-  } else {
-    xlab = ""
-    ylab = ""
-  }
-
-  plot(1:ni, item_exposure_rate_ordered, type = "n", lwd = 2, ylim = c(0, 1), xlab = "Item", ylab = "Exposure Rate", main = title)
-  points(1:ni, item_exposure_rate_ordered, type = "h", lwd = 1, col = color)
-  if (!is.null(stim_exposure_rate)) {
-    lines(1:ni, stim_exposure_rate_ordered, col = color_stim, type = "s")
-    for (stim_id in unique(stim_index_ordered)) {
-      x <- mean((1:ni)[which(stim_index_ordered == stim_id)])
-      y <- stim_exposure_rate_ordered[which(stim_index_ordered == stim_id)][1]
-      points(x, y, col = color_stim, pch = 21, bg = 'white', cex = .75)
-    }
-  }
-  abline(h = max_rate, col = color_threshold, lty = 2)
-
-  if (!is.null(item_exposure_rate_final)) {
-    item_exposure_rate_final_ordered <- item_exposure_rate_final[idx_sort]
-    points(1:ni, item_exposure_rate_final_ordered, type = "h", lwd = 1, lty = 1, col = color_final)
-  }
-}
 
 #' Calculate hyperparameters for log-normal distribution
 #'

--- a/README.Rmd
+++ b/README.Rmd
@@ -55,7 +55,7 @@ cfg <- createShadowTestConfig()
 solution <- Shadow(cfg, constraints, true_theta = c(0, 1))
 
 plot(solution, type = "audit" , examinee_id = 1)
-plot(solution, type = "shadow", examinee_id = 2, simple = T)
+plot(solution, type = "shadow", examinee_id = 2, simple = TRUE)
 summary(solution)
 
 ```

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ cfg <- createShadowTestConfig()
 solution <- Shadow(cfg, constraints, true_theta = c(0, 1))
 
 plot(solution, type = "audit" , examinee_id = 1)
-plot(solution, type = "shadow", examinee_id = 2, simple = T)
+plot(solution, type = "shadow", examinee_id = 2, simple = TRUE)
 summary(solution)
 ```
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,15 +1,13 @@
-# TestDesign 1.2.6
+# TestDesign 1.2.7
 
 ## Test environments
 
 * Local:
-* * Windows 10 (R 4.1.1)
-* * Ubuntu 20.04 (R 4.1.1)
+* * Windows 11 (R 4.1.2)
 * GitHub Actions:
-* * Windows Server 2019 (R-release)
-* * macOS Big Sur 11 (R-release)
 * * macOS Catalina 10.15 (R-release)
-* * Ubuntu 20.04 (R-release, R-devel, R-oldrel, R-3.6.3)
+* * Windows Server 2019 (R-release, R 3.6.3)
+* * Ubuntu 20.04 (R-devel, R-release, R-oldrel-1, R-oldrel-2)
 
 ## R CMD check results
 
@@ -27,7 +25,7 @@ Information on obtaining 'gurobi' is described in `DESCRIPTION`.
 
 ## Downstream dependencies
 
-The previous version 'TestDesign' 1.2.5 has 1 downstream dependency: `maat`
+The previous version 'TestDesign' 1.2.6 has 1 downstream dependency: 'maat' 1.0.2
 
 Downstream dependency was checked using 'revdepcheck' available from https://github.com/r-lib/revdepcheck
 

--- a/inst/shiny/server.r
+++ b/inst/shiny/server.r
@@ -211,12 +211,21 @@ server <- function(input, output, session) {
         if (input$simulee_id != "") {
           v <- updateLogs(v, sprintf("Created plots for simulee %i", v$simulee_id))
 
-          v$plot_output <- plot(v$fit, v$simulee_id, type = 'audit')
+          plot(v$fit, v$simulee_id, type = 'audit')
+          p <- recordPlot()
+          dev.off()
+
+          v$plot_output <- p
           assignObject(v$plot_output,
             sprintf("shiny_audit_plot_%i", v$simulee_id),
             sprintf("Audit trail plot for simulee %i", v$simulee_id)
           )
-          v$shadow_chart <- plot(v$fit, v$simulee_id, type = 'shadow', simple = TRUE)
+
+          plot(v$fit, v$simulee_id, type = 'shadow', simple = TRUE)
+          p <- recordPlot()
+          dev.off()
+
+          v$shadow_chart <- p
           assignObject(v$shadow_chart,
             sprintf("shiny_shadow_chart_%i", v$simulee_id),
             sprintf("Shadow test chart for simulee %i", v$simulee_id)
@@ -228,13 +237,19 @@ server <- function(input, output, session) {
 
   observeEvent(input$maxinfo_button, {
     if (v$itempool_exists & v$const_exists) {
-      v$info_range_plot <- plot(v$const)
+
+      plot(v$const)
+      p <- recordPlot()
+      dev.off()
+
+      v$info_range_plot <- p
       v$plot_output <- v$info_range_plot
       assignObject(v$info_range_plot,
         "shiny_info_range_plot",
         "Obtainable info range plot"
       )
       v <- updateLogs(v, "Info range plot is printed on the 'Main' tab.")
+
     }
     updateCheckboxGroupButtons(
       session = session,
@@ -242,7 +257,6 @@ server <- function(input, output, session) {
       selected = character(0)
     )
   })
-
 
   observeEvent(input$run_solver, {
     shinyjs::disable("run_solver")
@@ -297,7 +311,11 @@ server <- function(input, output, session) {
         if (is.null(v$fit@MIP)) {
           v <- updateLogs(v, "Solver did not find a solution. Try relaxing the target values.")
         } else {
-          v$plot_output <- plot(v$fit)
+          plot(v$fit)
+          p <- recordPlot()
+          dev.off()
+
+          v$plot_output <- p
 
           v <- updateLogs(v, sprintf("%-10s: solved in %3.3fs", conf@MIP$solver, v$fit@solve_time))
           v$selected_index <- which(v$fit@MIP[[1]]$solution == 1)

--- a/man/plot-methods.Rd
+++ b/man/plot-methods.Rd
@@ -30,6 +30,7 @@
   segment = NULL,
   rmse = FALSE,
   use_segment_label = TRUE,
+  use_par = TRUE,
   ...
 )
 
@@ -53,6 +54,7 @@
   segment = NULL,
   rmse = FALSE,
   use_segment_label = TRUE,
+  use_par = TRUE,
   ...
 )
 
@@ -74,6 +76,7 @@
   theta_segment = "Estimated",
   color_final = "blue",
   segment = NULL,
+  use_par = TRUE,
   ...
 )
 
@@ -96,6 +99,7 @@
   segment = NULL,
   rmse = FALSE,
   use_segment_label = TRUE,
+  use_par = TRUE,
   ...
 )
 
@@ -119,6 +123,7 @@
   segment = NULL,
   rmse = FALSE,
   use_segment_label = TRUE,
+  use_par = TRUE,
   ...
 )
 }
@@ -179,6 +184,8 @@
 \item{rmse}{used in \code{\linkS4class{output_Shadow_all}} with \code{type = 'exposure'}. If \code{TRUE}, display the RMSE value for each segment. (default = \code{FALSE})}
 
 \item{use_segment_label}{used in \code{\linkS4class{output_Shadow_all}} with \code{type = 'exposure'}. If \code{TRUE}, display the segment label for each segment. (default = \code{TRUE})}
+
+\item{use_par}{if \code{FALSE}, graphical parameters are not overridden inside the function. (default = \code{TRUE})}
 
 \item{...}{arguments to pass onto \code{\link[graphics]{plot}}.}
 }

--- a/man/plot-methods.Rd
+++ b/man/plot-methods.Rd
@@ -25,7 +25,7 @@
   color = "blue",
   z_ci = 1.96,
   simple = TRUE,
-  theta_segment = "Estimated",
+  theta_type = "Estimated",
   color_final = "blue",
   segment = NULL,
   rmse = FALSE,
@@ -49,7 +49,7 @@
   color = "blue",
   z_ci = 1.96,
   simple = TRUE,
-  theta_segment = "Estimated",
+  theta_type = "Estimated",
   color_final = "blue",
   segment = NULL,
   rmse = FALSE,
@@ -73,7 +73,7 @@
   color = "blue",
   z_ci = 1.96,
   simple = TRUE,
-  theta_segment = "Estimated",
+  theta_type = "Estimated",
   color_final = "blue",
   segment = NULL,
   use_par = TRUE,
@@ -94,7 +94,7 @@
   color = "blue",
   z_ci = 1.96,
   simple = FALSE,
-  theta_segment = "Estimated",
+  theta_type = "Estimated",
   color_final = "blue",
   segment = NULL,
   rmse = FALSE,
@@ -118,12 +118,13 @@
   color = "blue",
   z_ci = 1.96,
   simple = FALSE,
-  theta_segment = "Estimated",
+  theta_type = "Estimated",
   color_final = "blue",
   segment = NULL,
   rmse = FALSE,
   use_segment_label = TRUE,
   use_par = TRUE,
+  theta_segment = NULL,
   ...
 )
 }
@@ -175,7 +176,7 @@
 
 \item{simple}{used in \code{\linkS4class{output_Shadow}} and \code{\linkS4class{output_Shadow_all}} with \code{type = 'shadow'}. If \code{TRUE}, simplify the chart by hiding unused items.}
 
-\item{theta_segment}{used in \code{\linkS4class{output_Shadow_all}} with \code{type = 'exposure'}. The type of theta to determine exposure segments. Accepts \code{Estimated} or \code{True}. (default = \code{Estimated})}
+\item{theta_type}{used in \code{\linkS4class{output_Shadow_all}} with \code{type = 'exposure'}. The type of theta to determine exposure segments. Accepts \code{Estimated} or \code{True}. (default = \code{Estimated})}
 
 \item{color_final}{used in \code{\linkS4class{output_Shadow_all}} with \code{type = 'exposure'}. The color of item-wise exposure rates, only counting the items administered in the final theta segment as exposed.}
 
@@ -188,6 +189,8 @@
 \item{use_par}{if \code{FALSE}, graphical parameters are not overridden inside the function. (default = \code{TRUE})}
 
 \item{...}{arguments to pass onto \code{\link[graphics]{plot}}.}
+
+\item{theta_segment}{(deprecated) use \code{theta_type} argument instead.}
 }
 \description{
 Extension of plot() for objects in TestDesign package

--- a/man/plot-methods.Rd
+++ b/man/plot-methods.Rd
@@ -49,11 +49,6 @@
   color = "blue",
   z_ci = 1.96,
   simple = TRUE,
-  theta_type = "Estimated",
-  color_final = "blue",
-  segment = NULL,
-  rmse = FALSE,
-  use_segment_label = TRUE,
   use_par = TRUE,
   ...
 )
@@ -73,9 +68,6 @@
   color = "blue",
   z_ci = 1.96,
   simple = TRUE,
-  theta_type = "Estimated",
-  color_final = "blue",
-  segment = NULL,
   use_par = TRUE,
   ...
 )
@@ -95,10 +87,6 @@
   z_ci = 1.96,
   simple = FALSE,
   theta_type = "Estimated",
-  color_final = "blue",
-  segment = NULL,
-  rmse = FALSE,
-  use_segment_label = TRUE,
   use_par = TRUE,
   ...
 )

--- a/tests/testthat/test_exposure_methods.R
+++ b/tests/testthat/test_exposure_methods.R
@@ -1,7 +1,7 @@
 test_that("exposure control works", {
 
   skip_on_cran()
-  skip_on_travis()
+  skip_on_ci()
 
   set.seed(1)
   true_theta <- runif(100, -3.5, 3.5)

--- a/tests/testthat/test_plot_functions.r
+++ b/tests/testthat/test_plot_functions.r
@@ -1,0 +1,26 @@
+cfg <- createStaticTestConfig()
+o <- Static(cfg, constraints_science)
+
+test_that("plot functions work", {
+  plot(o, type = "info")
+  plot(o, type = "score")
+  expect_true(TRUE)
+})
+
+cfg <- createShadowTestConfig()
+o <- Shadow(cfg, constraints_science, true_theta = c(0, 1), seed = 1)
+
+test_that("plot functions work", {
+  plot(o, type = "info")
+  plot(o, type = "audit")
+  plot(o, type = "shadow")
+  plot(o, type = "exposure")
+  expect_true(TRUE)
+})
+
+test_that("plot functions work", {
+  plot(itempool_science, type = "info")
+  plot(itempool_science, type = "score")
+  plot(constraints_science, type = "info")
+  expect_true(TRUE)
+})


### PR DESCRIPTION
* `plot()` now works better with 'knitr' markdown documents. This is enabled by removing the use of `recordPlot()` inside `plot()`. As a result, `p <- plot()` will not work anymore. Use `recordPlot()` for assigning plots into objects.
* Shiny app `TestDesign()` is updated to work with the above change.
* `plot()` gains a new `use_par` argument to override using default graphical parameters that are hard-coded into the function. This allows for more flexible formatting.
* `theta_segment` argument in `plot(type = "exposure")` is renamed to `theta_type`. The existing argument is deprecated and using it will raise a warning.
* added validation check for test length constraints. In shadow test approach, test length is expected to be a fixed value.