### PR TITLE
add soft exclusion option

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # TestDesign 1.3.1.9000
 
+## New features
+
+* `config_Shadow` and `createShadowTestConfig()` gain a new slot `exclude_policy` for configuring how excluded items are treated. Excluded items are supplied through the `exclude` argument in `Shadow()`.
+
 ## Updates
 
 * Shiny app `TestDesign()` gains a 'close app' button.

--- a/R/other_functions.R
+++ b/R/other_functions.R
@@ -43,6 +43,8 @@ getConstants <- function(constraints, config, arg_data, true_theta, max_info) {
     o$max_se         <- config@stopping_criterion$se_threshold
   }
 
+  o$exclude_method <- toupper(config@exclude_policy$method)
+
   refresh_method <- toupper(config@refresh_policy$method)
   if (refresh_method %in% c("STIMULUS", "SET", "PASSAGE")) {
     o$set_based_refresh <- TRUE

--- a/R/other_functions.R
+++ b/R/other_functions.R
@@ -44,6 +44,7 @@ getConstants <- function(constraints, config, arg_data, true_theta, max_info) {
   }
 
   o$exclude_method <- toupper(config@exclude_policy$method)
+  o$exclude_M      <- config@exclude_policy$M
 
   refresh_method <- toupper(config@refresh_policy$method)
   if (refresh_method %in% c("STIMULUS", "SET", "PASSAGE")) {

--- a/R/shadow_class.R
+++ b/R/shadow_class.R
@@ -397,8 +397,22 @@ createShadowTestConfig <- function(
   obj_names <- c()
   for (arg in arg_names) {
     if (!is.null(eval(parse(text = arg)))) {
-      eval(parse(text = paste0("obj_names <- names(cfg@", arg, ")")))
-      for (entry in obj_names) {
+      accepted_slots <-
+        eval(parse(text = sprintf("names(cfg@%s)", arg)))
+      supplied_slots <-
+        eval(parse(text = sprintf("names(%s)", arg)))
+      leftovers <- setdiff(supplied_slots, accepted_slots)
+      if (length(leftovers) > 0) {
+        for (x in leftovers) {
+          stop(
+            sprintf(
+              "cfg@%s: slot '%s' is unused",
+              arg, x
+            )
+          )
+        }
+      }
+      for (entry in accepted_slots) {
         entry_l <- paste0("cfg@", arg, "$", entry)
         entry_r <- paste0(arg, "$", entry)
         tmp <- eval(parse(text = entry_r))

--- a/R/shadow_class.R
+++ b/R/shadow_class.R
@@ -225,6 +225,18 @@ setClass("config_Shadow",
       msg <- sprintf("config@exclude_policy: unrecognized $method '%s' (accepts HARD, or SOFT)", object@exclude_policy$method)
       err <- c(err, msg)
     }
+    if (object@exclude_policy$method == "SOFT") {
+      if (!is.numeric(object@exclude_policy$M)) {
+        msg <- sprintf("$method 'SOFT' requires $M to be a positive value")
+        err <- c(err, msg)
+      }
+      if (is.numeric(object@exclude_policy$M)) {
+        if (object@exclude_policy$M < 0) {
+          msg <- sprintf("$method 'SOFT' requires $M to be a positive value")
+          err <- c(err, msg)
+        }
+      }
+    }
     if (!object@refresh_policy$method %in%
       c("ALWAYS", "POSITION", "INTERVAL", "THRESHOLD", "INTERVAL-THRESHOLD", "STIMULUS", "SET", "PASSAGE")) {
       msg <- sprintf("config@refresh_policy: unrecognized $method '%s'", object@refresh_policy$method)
@@ -233,6 +245,18 @@ setClass("config_Shadow",
     if (!object@exposure_control$method %in% c("NONE", "ELIGIBILITY", "BIGM", "BIGM-BAYESIAN")) {
       msg <- sprintf("config@exposure_control: unrecognized $method '%s' (accepts NONE, ELIGIBILITY, BIGM, or BIGM-BAYESIAN)", object@exposure_control$method)
       err <- c(err, msg)
+    }
+    if (object@exposure_control$method %in% c("BIGM", "BIGM-BAYESIAN")) {
+      if (!is.numeric(object@exposure_control$M)) {
+        msg <- sprintf("$method 'BIGM', 'BIGM-BAYESIAM' requires $M to be a positive value")
+        err <- c(err, msg)
+      }
+      if (is.numeric(object@exposure_control$M)) {
+        if (object@exposure_control$M < 0) {
+          msg <- sprintf("$method 'BIGM', 'BIGM-BAYESIAM' requires $M to be a positive value")
+          err <- c(err, msg)
+        }
+      }
     }
     if (toupper(object@item_selection$method) %in% c("GFI") &
       object@exposure_control$method %in% c("ELIGIBILITY")) {

--- a/R/shadow_class.R
+++ b/R/shadow_class.R
@@ -227,8 +227,10 @@ setClass("config_Shadow",
     }
     if (object@exclude_policy$method == "SOFT") {
       if (!is.numeric(object@exclude_policy$M)) {
-        msg <- sprintf("$method 'SOFT' requires $M to be a positive value")
-        err <- c(err, msg)
+        if (!is.null(object@exclude_policy$M)) {
+          msg <- sprintf("$method 'SOFT' requires $M to be a positive value")
+          err <- c(err, msg)
+        }
       }
       if (is.numeric(object@exclude_policy$M)) {
         if (object@exclude_policy$M < 0) {
@@ -248,8 +250,10 @@ setClass("config_Shadow",
     }
     if (object@exposure_control$method %in% c("BIGM", "BIGM-BAYESIAN")) {
       if (!is.numeric(object@exposure_control$M)) {
-        msg <- sprintf("$method 'BIGM', 'BIGM-BAYESIAM' requires $M to be a positive value")
-        err <- c(err, msg)
+        if (!is.null(object@exposure_control$M)) {
+          msg <- sprintf("$method 'BIGM', 'BIGM-BAYESIAM' requires $M to be a positive value")
+          err <- c(err, msg)
+        }
       }
       if (is.numeric(object@exposure_control$M)) {
         if (object@exposure_control$M < 0) {

--- a/R/shadow_class.R
+++ b/R/shadow_class.R
@@ -127,7 +127,8 @@ setClass("config_Shadow",
       jump_factor               = 1
     ),
     exclude_policy = list(
-      method = "HARD"
+      method = "HARD",
+      M = NULL
     ),
     refresh_policy = list(
       method                    = "ALWAYS",
@@ -321,6 +322,7 @@ setClass("config_Shadow",
 #' @param exclude_policy a named list containing the exclude policy for use with the \code{exclude} argument in \code{\link{Shadow}}.
 #' \itemize{
 #'   \item{\code{method}} the type of policy. Accepts \code{HARD, SOFT}. (default = \code{HARD})
+#'   \item{\code{M}} the Big M penalty to use on item information. Used in the \code{SOFT} method.
 #' }
 #' @param refresh_policy a named list containing the refresh policy for when to obtain a new shadow test.
 #' \itemize{

--- a/R/shadow_class.R
+++ b/R/shadow_class.R
@@ -92,6 +92,7 @@ setClass("config_Shadow",
     content_balancing  = "list",
     MIP                = "list",
     MCMC               = "list",
+    exclude_policy     = "list",
     refresh_policy     = "list",
     exposure_control   = "list",
     stopping_criterion = "list",
@@ -124,6 +125,9 @@ setClass("config_Shadow",
       post_burn_in              = 500,
       thin                      = 1,
       jump_factor               = 1
+    ),
+    exclude_policy = list(
+      method = "HARD"
     ),
     refresh_policy = list(
       method                    = "ALWAYS",
@@ -213,6 +217,11 @@ setClass("config_Shadow",
 
     if (!object@content_balancing$method %in% c("NONE", "STA")) {
       msg <- sprintf("config@content_balancing: unrecognized $method '%s' (accepts NONE, or STA)", object@content_balancing$method)
+      err <- c(err, msg)
+    }
+    if (!object@exclude_policy$method %in%
+      c("HARD", "SOFT")) {
+      msg <- sprintf("config@exclude_policy: unrecognized $method '%s' (accepts HARD, or SOFT)", object@exclude_policy$method)
       err <- c(err, msg)
     }
     if (!object@refresh_policy$method %in%

--- a/R/shadow_class.R
+++ b/R/shadow_class.R
@@ -318,6 +318,10 @@ setClass("config_Shadow",
 #'   \item{\code{thin}} thinning interval to apply. \code{1} represents no thinning. (default = \code{1})
 #'   \item{\code{jump_factor}} the jump factor to use. \code{1} represents no jumping. (default = \code{1})
 #' }
+#' @param exclude_policy a named list containing the exclude policy for use with the \code{exclude} argument in \code{\link{Shadow}}.
+#' \itemize{
+#'   \item{\code{method}} the type of policy. Accepts \code{HARD, SOFT}. (default = \code{HARD})
+#' }
 #' @param refresh_policy a named list containing the refresh policy for when to obtain a new shadow test.
 #' \itemize{
 #'   \item{\code{method}} the type of policy. Accepts \code{ALWAYS, POSITION, INTERVAL, THRESHOLD, INTERVAL-THRESHOLD, STIMULUS, SET, PASSAGE}. (default = \code{ALWAYS})
@@ -394,13 +398,13 @@ setClass("config_Shadow",
 #' @export
 createShadowTestConfig <- function(
   item_selection = NULL, content_balancing = NULL, MIP = NULL, MCMC = NULL,
-  refresh_policy = NULL, exposure_control = NULL, stopping_criterion = NULL,
+  exclude_policy = NULL, refresh_policy = NULL, exposure_control = NULL, stopping_criterion = NULL,
   interim_theta = NULL, final_theta = NULL, theta_grid = seq(-4, 4, .1)) {
   cfg <- new("config_Shadow")
 
   arg_names <- c(
     "item_selection", "content_balancing", "MIP", "MCMC",
-    "refresh_policy", "exposure_control", "stopping_criterion",
+    "exclude_policy", "refresh_policy", "exposure_control", "stopping_criterion",
     "interim_theta", "final_theta"
   )
   obj_names <- c()

--- a/R/shadowtest_functions.R
+++ b/R/shadowtest_functions.R
@@ -16,8 +16,13 @@ assembleShadowTest <- function(
   administered_stimulus_index <- na.omit(unique(o@administered_stimulus_index))
 
   xdata         <- getXdataOfAdministered(constants, position, o, stimulus_record, constraints)
-  xdata_exclude <- getXdataOfExcludedEntry(constants, exclude_index[[j]])
-  xdata         <- combineXdata(xdata, xdata_exclude)
+  if (constants$exclude_method == "HARD") {
+    xdata_exclude <- getXdataOfExcludedEntry(constants, exclude_index[[j]])
+    xdata         <- combineXdata(xdata, xdata_exclude)
+  }
+  if (constants$exclude_method == "SOFT") {
+    info <- getInfoOfExcludedEntry(info, exclude_index[[j]], constants)
+  }
 
   if (constants$use_eligibility_control) {
 

--- a/R/static_class.R
+++ b/R/static_class.R
@@ -137,8 +137,22 @@ createStaticTestConfig <- function(item_selection = NULL, MIP = NULL) {
   obj_names <- c()
   for (arg in arg_names) {
     if (!is.null(eval(parse(text = arg)))) {
-      eval(parse(text = paste0("obj_names <- names(cfg@", arg, ")")))
-      for (entry in obj_names) {
+      accepted_slots <-
+        eval(parse(text = sprintf("names(cfg@%s)", arg)))
+      supplied_slots <-
+        eval(parse(text = sprintf("names(%s)", arg)))
+      leftovers <- setdiff(supplied_slots, accepted_slots)
+      if (length(leftovers) > 0) {
+        for (x in leftovers) {
+          stop(
+            sprintf(
+              "cfg@%s: slot '%s' is unused",
+              arg, x
+            )
+          )
+        }
+      }
+      for (entry in accepted_slots) {
         entry_l <- paste0("cfg@", arg, "$", entry)
         entry_r <- paste0(arg, "$", entry)
         tmp <- eval(parse(text = entry_r))

--- a/R/xdata_functions.R
+++ b/R/xdata_functions.R
@@ -153,3 +153,20 @@ combineXdata <- function(x1, x2) {
   return(o)
 
 }
+
+#' @noRd
+getInfoOfExcludedEntry <- function(info, exclude_index, constants) {
+
+  info[exclude_index$i, 1] <-
+  info[exclude_index$i, 1] - constants$exclude_M
+
+  if (!constants$set_based) {
+    return(info)
+  }
+
+  info[exclude_index$s, 1] <-
+  info[exclude_index$s, 1] - constants$exclude_M
+
+  return(info)
+
+}

--- a/man/createShadowTestConfig.Rd
+++ b/man/createShadowTestConfig.Rd
@@ -11,6 +11,7 @@ createShadowTestConfig(
   content_balancing = NULL,
   MIP = NULL,
   MCMC = NULL,
+  exclude_policy = NULL,
   refresh_policy = NULL,
   exposure_control = NULL,
   stopping_criterion = NULL,
@@ -51,6 +52,11 @@ createShadowTestConfig(
   \item{\code{post_burn_in}} the number of chains to use after discarding the first \code{burn_in} chains. (default = \code{500})
   \item{\code{thin}} thinning interval to apply. \code{1} represents no thinning. (default = \code{1})
   \item{\code{jump_factor}} the jump factor to use. \code{1} represents no jumping. (default = \code{1})
+}}
+
+\item{exclude_policy}{a named list containing the exclude policy for use with the \code{exclude} argument in \code{\link{Shadow}}.
+\itemize{
+  \item{\code{method}} the type of policy. Accepts \code{HARD, SOFT}. (default = \code{HARD})
 }}
 
 \item{refresh_policy}{a named list containing the refresh policy for when to obtain a new shadow test.

--- a/man/createShadowTestConfig.Rd
+++ b/man/createShadowTestConfig.Rd
@@ -57,6 +57,7 @@ createShadowTestConfig(
 \item{exclude_policy}{a named list containing the exclude policy for use with the \code{exclude} argument in \code{\link{Shadow}}.
 \itemize{
   \item{\code{method}} the type of policy. Accepts \code{HARD, SOFT}. (default = \code{HARD})
+  \item{\code{M}} the Big M penalty to use on item information. Used in the \code{SOFT} method.
 }}
 
 \item{refresh_policy}{a named list containing the refresh policy for when to obtain a new shadow test.


### PR DESCRIPTION
- Added a new option for configuring how excluded items are treated. For this, `config_Shadow` and `createShadowTestConfig()` gain a new `exclude_policy` slot.
- `create*Config()` functions now explicitly raise an error when values are present in undefined/unused slot names.