### PR TITLE
TestDesign 1.3.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: TestDesign
 Type: Package
 Title: Optimal Test Design Approach to Fixed and Adaptive Test Construction
-Version: 1.3.1.9000
-Date: 2022-03-31
+Version: 1.3.2
+Date: 2022-04-20
 Authors@R: c(
     person("Seung W.", "Choi",
         email = "schoi@austin.utexas.edu",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# TestDesign 1.3.1.9000
+# TestDesign 1.3.2
 
 ## New features
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,12 +1,12 @@
-# TestDesign 1.3.0
+# TestDesign 1.3.2
 
 ## Test environments
 
 * Local:
 * * Windows 11 (R 4.1.2)
 * GitHub Actions:
-* * macOS Catalina 10.15 (R-release)
-* * Windows Server 2019 (R-release, R 3.6.3)
+* * macOS Big Sur 11 (R-release)
+* * Windows Server 2022 (R-release)
 * * Ubuntu 20.04 (R-devel, R-release, R-oldrel-1, R-oldrel-2)
 
 ## R CMD check results
@@ -25,7 +25,7 @@ Information on obtaining 'gurobi' is described in `DESCRIPTION`.
 
 ## Downstream dependencies
 
-The previous version 'TestDesign' 1.2.7 has 1 downstream dependency: 'maat' 1.0.2
+The previous version 'TestDesign' 1.3.1 has 1 downstream dependency: 'maat' 1.0.2
 
 Downstream dependency was checked using 'revdepcheck' available from https://github.com/r-lib/revdepcheck
 


### PR DESCRIPTION
## New features

* `config_Shadow` and `createShadowTestConfig()` gain a new slot `exclude_policy` for configuring how excluded items are treated. Excluded items are supplied through the `exclude` argument in `Shadow()`.

## Updates

* Shiny app `TestDesign()` gains a 'close app' button.

## Bug fixes

* Fixed where the Shiny app was not starting normally.
* Fixed where attempting to use an exposure acceleration factor greater than 1 in set-based adaptive assembly using `Shadow()` would trigger a 'incorrect number of subscripts' error.
