### PR TITLE
fix pkgdown not building

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -106,6 +106,8 @@ reference:
       - test_cluster-class
       - makeTest
       - makeTestCluster
+      - simulation_data_cache-class
+      - makeSimulationDataCache
       - lnHyperPars
       - logitHyperPars
       - iparPosteriorSample


### PR DESCRIPTION
## Description

- `pkgdown` page build was failing after #120.
- This was because the new function `makeSimulationDataCache` and the new class `simulation_data_cache-class` introduced in #120 were not listed in `_pkgdown.yml`, which is the index file used to build `pkgdown` pages. 
- `pkgdown` expects all classes and functions to be listed in `_pkgdown.yml`, regardless of whether they are `@export`ed or not.
- This fix adds `makeSimulationDataCache` and `simulation_data_cache-class` as internal entries in `_pkgdown.yml`.