### PR TITLE
fix `Shadow()` to work when `FIXED` item selection is used

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,11 @@
 
 * Fixed where `Shadow()` was not working when `data` was supplied with `true_theta` left empty. (#118)
 * Fixed where `BIGM` exposure control was ignoring the `M` value and defaulting to (maximum information + 1) even when it was supplied.
+* Fixed where `Shadow()` was not working when the `FIXED` item selection method was used with a single `$fixed_theta` value in the config. (#132)
+
+## Updates
+
+* The `FIXED` item selection method for `Shadow()` now does not approximate the supplied value to the nearest theta quadrature when computing information.
 
 # TestDesign 1.3.3
 

--- a/R/other_functions.R
+++ b/R/other_functions.R
@@ -201,8 +201,8 @@ getInfoFixedTheta <- function(item_selection, constants, pool, model) {
 #' @noRd
 computeInfoAtCurrentTheta <- function(
   item_selection, j,
-  info_fixed_theta,
   current_theta, pool, model, posterior_record,
+  info_fixed_theta,
   info_grid
 ) {
 

--- a/R/other_functions.R
+++ b/R/other_functions.R
@@ -180,8 +180,7 @@ getInfoFixedTheta <- function(item_selection, constants, info_cache, pool, model
 
   if (!is.null(item_selection$fixed_theta)) {
     if (length(item_selection$fixed_theta) == 1) {
-      o$info_fixed_theta <- vector(mode = "list", length = nj)
-      o$info_fixed_theta <- info_cache[which.min(abs(constants$theta_grid - item_selection$fixed_theta)), ]
+      o$info_fixed_theta <- lapply(seq_len(nj), function(j) calc_info(item_selection$fixed_theta, pool@ipar, pool@NCAT, model))
       o$select_at_fixed_theta <- TRUE
     }
     if (length(item_selection$fixed_theta) == nj) {

--- a/R/other_functions.R
+++ b/R/other_functions.R
@@ -199,7 +199,12 @@ getInfoFixedTheta <- function(item_selection, constants, pool, model) {
 }
 
 #' @noRd
-computeInfoAtCurrentTheta <- function(item_selection, j, info_fixed_theta, current_theta, pool, model, posterior_record, info_grid) {
+computeInfoAtCurrentTheta <- function(
+  item_selection, j,
+  info_fixed_theta,
+  current_theta, pool, model, posterior_record,
+  info_grid
+) {
 
   item_method <- toupper(item_selection$method)
   info_type   <- toupper(item_selection$info_type)

--- a/R/other_functions.R
+++ b/R/other_functions.R
@@ -173,7 +173,7 @@ initializeShadowEngine <- function(constants, refresh_policy) {
 }
 
 #' @noRd
-getInfoFixedTheta <- function(item_selection, constants, info_cache, pool, model) {
+getInfoFixedTheta <- function(item_selection, constants, pool, model) {
 
   nj <- constants$nj
   o <- list()

--- a/R/shadow_functions.R
+++ b/R/shadow_functions.R
@@ -75,7 +75,7 @@ setMethod(
       response_data = data
     )
     constants             <- getConstants(constraints, config, data, true_theta, simulation_data_cache@max_info)
-    info_fixed_theta      <- getInfoFixedTheta(config@item_selection, constants, simulation_data_cache@info_grid, pool, model)
+    info_fixed_theta      <- getInfoFixedTheta(config@item_selection, constants, pool, model)
     posterior_constants   <- getPosteriorConstants(config)
     posterior_record      <- initializePosterior(prior, prior_par, config, constants, pool, posterior_constants)
     initial_theta         <- initializeTheta(config, constants, posterior_record)

--- a/R/shadow_functions.R
+++ b/R/shadow_functions.R
@@ -194,11 +194,11 @@ setMethod(
         position <- position + 1
         info_current_theta <- computeInfoAtCurrentTheta(
           config@item_selection, j,
-          info_fixed_theta,               # Only used if config@item_selection$method = "FIXED"
           current_theta,
           pool,
           model,
           posterior_record,
+          info_fixed_theta,               # Only used if config@item_selection$method = "FIXED"
           simulation_data_cache@info_grid # Only used if config@item_selection$method = "MPWI"
         )
 

--- a/R/shadow_functions.R
+++ b/R/shadow_functions.R
@@ -75,11 +75,13 @@ setMethod(
       response_data = data
     )
     constants             <- getConstants(constraints, config, data, true_theta, simulation_data_cache@max_info)
-    info_fixed_theta      <- getInfoFixedTheta(config@item_selection, constants, pool, model)
     posterior_constants   <- getPosteriorConstants(config)
     posterior_record      <- initializePosterior(prior, prior_par, config, constants, pool, posterior_constants)
     initial_theta         <- initializeTheta(config, constants, posterior_record)
     exclude_index         <- getIndexOfExcludedEntry(exclude, constraints)
+
+    # Only used if config@item_selection$method = "FIXED"
+    info_fixed_theta      <- getInfoFixedTheta(config@item_selection, constants, pool, model)
 
     if (constants$use_shadow) {
       refresh_shadow <- initializeShadowEngine(constants, config@refresh_policy)
@@ -191,8 +193,13 @@ setMethod(
 
         position <- position + 1
         info_current_theta <- computeInfoAtCurrentTheta(
-          config@item_selection, j, info_fixed_theta, current_theta, pool, model,
-          posterior_record, simulation_data_cache@info_grid
+          config@item_selection, j,
+          info_fixed_theta,               # Only used if config@item_selection$method = "FIXED"
+          current_theta,
+          pool,
+          model,
+          posterior_record,
+          simulation_data_cache@info_grid # Only used if config@item_selection$method = "MPWI"
         )
 
         # Item position / simulee: do shadow test assembly


### PR DESCRIPTION
## Description

- Fixed where `Shadow()` was not working when the `FIXED` item selection method was used with a single `$fixed_theta` value in the config. (#132)
- The supplied `$fixed_theta` value is now used as-is, instead of being approximated to the nearest theta quadrature. This value is only utilized once in the beginning of `Shadow()` to precompute information, so this change does not affect the main simulation.