### PR TITLE
fix `M` being ignored even when it was supplied

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 * Fixed where `Shadow()` was not working when `data` was supplied with `true_theta` left empty. (#118)
+* Fixed where `BIGM` exposure control was ignoring the `M` value and defaulting to (maximum information + 1) even when it was supplied.
 
 # TestDesign 1.3.3
 

--- a/R/eligibility_functions.R
+++ b/R/eligibility_functions.R
@@ -106,22 +106,14 @@ applyEligibilityConstraintsToXdata <- function(xdata, eligible_flag_in_current_t
 #' @noRd
 applyEligibilityConstraintsToInfo <- function(o, eligible_flag_in_current_theta_segment, config, constants) {
 
-  if (is.null(constants$M) & config@item_selection$method == "GFI") {
-    o[eligible_flag_in_current_theta_segment$i == 0] <- 1 * constants$max_info + 1 # add because GFI performs minimization
-    return(o)
-  }
-  if (is.null(constants$M) & config@item_selection$method != "GFI") {
-    o[eligible_flag_in_current_theta_segment$i == 0] <- -1 * constants$max_info - 1
-    return(o)
-  }
-  if (!is.null(constants$M) & config@item_selection$method == "GFI") {
+  if (config@item_selection$method == "GFI") {
     o[eligible_flag_in_current_theta_segment$i == 0] <-
-    o[eligible_flag_in_current_theta_segment$i == 0] + constants$M # add because GFI performs minimization
+    o[eligible_flag_in_current_theta_segment$i == 0] + constants$exposure_M # add because GFI performs minimization
     return(o)
   }
-  if (!is.null(constants$M) & config@item_selection$method != "GFI") {
+  if (config@item_selection$method != "GFI") {
     o[eligible_flag_in_current_theta_segment$i == 0] <-
-    o[eligible_flag_in_current_theta_segment$i == 0] - constants$M
+    o[eligible_flag_in_current_theta_segment$i == 0] - constants$exposure_M
     return(o)
   }
 

--- a/R/other_functions.R
+++ b/R/other_functions.R
@@ -106,6 +106,10 @@ getConstants <- function(constraints, config, arg_data, true_theta, max_info) {
   } else {
     o$use_eligibility_control <- FALSE
   }
+  o$exposure_M <- config@exposure_control$M
+  if (is.null(o$exposure_M)) {
+    o$exposure_M <- max_info + 1
+  }
 
   o$max_exposure_rate   <- config@exposure_control$max_exposure_rate
   o$fading_factor       <- config@exposure_control$fading_factor
@@ -118,8 +122,6 @@ getConstants <- function(constraints, config, arg_data, true_theta, max_info) {
   if (!length(o$max_exposure_rate) %in% c(1, o$n_segment)) {
     stop("length(max_exposure_rate) must be 1 or n_segment")
   }
-
-  o$max_info <- max_info
 
   return(o)
 


### PR DESCRIPTION
## Description

- Fixed where `M` value was being ignored for exposure control even when it was supplied. (#134)
- The cause of the error was that `getConstants()` was not populating `$M`, and therefore `constants$M` was always `NULL` in `applyEligibilityConstraintsToInfo()`.
- `constants$max_info` had no other uses than as a fallback value of `M`, and thus was removed.