### PR TITLE
use matrix theta quadratures

### DIFF
--- a/R/bayes_functions.R
+++ b/R/bayes_functions.R
@@ -69,7 +69,7 @@ getPosteriorConstants <- function(config) {
 #' @noRd
 generateDistributionFromPriorPar <- function(dist_type, prior_par, theta_q, nj) {
 
-  nq <- length(theta_q)
+  nq <- nrow(theta_q)
   m  <- NULL
 
   if (dist_type == "NORMAL" && is.vector(prior_par) && length(prior_par) == 2) {

--- a/R/bayes_functions.R
+++ b/R/bayes_functions.R
@@ -67,19 +67,19 @@ getPosteriorConstants <- function(config) {
 }
 
 #' @noRd
-generateDistributionFromPriorPar <- function(dist_type, prior_par, theta_grid, nj) {
+generateDistributionFromPriorPar <- function(dist_type, prior_par, theta_q, nj) {
 
-  nq <- length(theta_grid)
+  nq <- length(theta_q)
   m  <- NULL
 
   if (dist_type == "NORMAL" && is.vector(prior_par) && length(prior_par) == 2) {
-    x <- dnorm(theta_grid, mean = prior_par[1], sd = prior_par[2])
+    x <- dnorm(theta_q, mean = prior_par[1], sd = prior_par[2])
     m <- matrix(x, nj, nq, byrow = TRUE)
   }
   if (dist_type == "NORMAL" && is.matrix(prior_par) && all(dim(prior_par) == c(nj, 2))) {
     m <- matrix(NA, nj, nq, byrow = TRUE)
     for (j in 1:nj) {
-      m[j, ] <- dnorm(theta_grid, mean = prior_par[j, 1], sd = prior_par[j, 2])
+      m[j, ] <- dnorm(theta_q, mean = prior_par[j, 1], sd = prior_par[j, 2])
     }
   }
   if (dist_type == "UNIFORM") {

--- a/R/bayes_functions.R
+++ b/R/bayes_functions.R
@@ -75,22 +75,22 @@ generateDistributionFromPriorPar <- function(dist_type, prior_par, theta_q, nj) 
   if (dist_type == "NORMAL" && is.vector(prior_par) && length(prior_par) == 2) {
     x <- dnorm(theta_q, mean = prior_par[1], sd = prior_par[2])
     m <- matrix(x, nj, nq, byrow = TRUE)
+    return(m)
   }
   if (dist_type == "NORMAL" && is.matrix(prior_par) && all(dim(prior_par) == c(nj, 2))) {
     m <- matrix(NA, nj, nq, byrow = TRUE)
     for (j in 1:nj) {
       m[j, ] <- dnorm(theta_q, mean = prior_par[j, 1], sd = prior_par[j, 2])
     }
+    return(m)
   }
   if (dist_type == "UNIFORM") {
     x <- 1
     m <- matrix(x, nj, nq, byrow = TRUE)
-  }
-  if (is.null(m)) {
-    stop("unrecognized 'prior_par': must be a vector c(mean, sd), or a nj * 2 matrix")
+    return(m)
   }
 
-  return(m)
+  stop("unrecognized 'prior_par': must be a vector c(mean, sd), or a nj * 2 matrix")
 
 }
 

--- a/R/bayes_functions.R
+++ b/R/bayes_functions.R
@@ -4,9 +4,9 @@ NULL
 #' @noRd
 initializePosterior <- function(prior, prior_par, config, constants, pool, posterior_constants) {
 
-  theta_grid <- constants$theta_q
-  nj         <- constants$nj
-  nq         <- constants$nq
+  theta_q <- constants$theta_q
+  nj      <- constants$nj
+  nq      <- constants$nq
 
   o <- list()
 
@@ -17,14 +17,14 @@ initializePosterior <- function(prior, prior_par, config, constants, pool, poste
     o$posterior <- generateDistributionFromPriorPar(
       toupper(config@interim_theta$prior_dist),
       config@interim_theta$prior_par,
-      theta_grid, nj
+      theta_q, nj
     )
   }
   if (is.null(prior) && !is.null(prior_par)) {
     o$posterior <- generateDistributionFromPriorPar(
       "NORMAL",
       prior_par,
-      theta_grid, nj
+      theta_q, nj
     )
   }
   if (is.vector(prior) && length(prior) == nq) {

--- a/R/other_functions.R
+++ b/R/other_functions.R
@@ -9,9 +9,12 @@ getConstants <- function(constraints, config, arg_data, true_theta, max_info) {
   o$ns <- constraints@ns
   o$nv <- constraints@nv
   o$theta_q <- config@theta_grid
-  o$nq      <- length(config@theta_grid)
-  o$min_q   <- min(config@theta_grid)
-  o$max_q   <- max(config@theta_grid)
+  if (inherits(o$theta_q, "numeric")) {
+    o$theta_q <- matrix(o$theta_q, , 1)
+  }
+  o$nq      <- nrow(o$theta_q)
+  o$min_q   <- min(o$theta_q)
+  o$max_q   <- max(o$theta_q)
 
   if (!is.null(arg_data)) {
     o$nj <- nrow(arg_data)


### PR DESCRIPTION
## Description

- Theta quadratures used for internal computation are now typecasted to a matrix, with the number of rows being the number of quadratures.
- This was done to prepare for multidimensional cases.