### PR TITLE
use matrix interim theta

### DIFF
--- a/R/other_functions.R
+++ b/R/other_functions.R
@@ -8,6 +8,7 @@ getConstants <- function(constraints, config, arg_data, true_theta, max_info) {
   o$ni <- constraints@ni
   o$ns <- constraints@ns
   o$nv <- constraints@nv
+  o$nd <- 1
   o$theta_q <- config@theta_grid
   if (inherits(o$theta_q, "numeric")) {
     o$theta_q <- matrix(o$theta_q, , 1)

--- a/R/shadow_functions.R
+++ b/R/shadow_functions.R
@@ -138,8 +138,8 @@ setMethod(
       o@administered_item_resp      <- rep(NA_real_, constants$max_ni)
       o@administered_stimulus_index <- NaN
       o@theta_segment_index         <- rep(NA_real_, constants$max_ni)
-      o@interim_theta_est           <- rep(NA_real_, constants$max_ni)
-      o@interim_se_est              <- rep(NA_real_, constants$max_ni)
+      o@interim_theta_est           <- matrix(NA_real_, constants$max_ni, constants$nd)
+      o@interim_se_est              <- matrix(NA_real_, constants$max_ni, constants$nd)
       o@shadow_test                 <- vector("list", constants$max_ni)
       o@max_cat_pool                <- item_pool@max_cat
       o@test_length_constraints     <- constants$max_ni

--- a/R/shadow_functions.R
+++ b/R/shadow_functions.R
@@ -364,10 +364,10 @@ setMethod(
           posterior_constants
         )
 
-        theta_change                   <- o@interim_theta_est[position] - current_theta$theta
+        theta_change                   <- o@interim_theta_est[position, ] - current_theta$theta
         current_theta$posterior_sample <- o@posterior_sample
-        current_theta$theta            <- o@interim_theta_est[position]
-        current_theta$se               <- o@interim_se_est[position]
+        current_theta$theta            <- o@interim_theta_est[position, ]
+        current_theta$se               <- o@interim_se_est[position, ]
 
         # Item position / simulee: prepare for the next item position
 

--- a/R/theta_functions.R
+++ b/R/theta_functions.R
@@ -21,8 +21,8 @@ estimateInterimTheta <- function(
       position > 1
     ) {
       # skip update and reuse previous interim theta estimate
-      o@interim_theta_est[position] <- o@interim_theta_est[position - 1]
-      o@interim_se_est[position]    <- o@interim_se_est[position - 1]
+      o@interim_theta_est[position, ] <- o@interim_theta_est[position - 1, ]
+      o@interim_se_est[position, ]    <- o@interim_se_est[position - 1, ]
       return(o)
     }
     if (
@@ -30,8 +30,8 @@ estimateInterimTheta <- function(
       position == 1
     ) {
       # skip update and reuse previous interim theta estimate (starting theta)
-      o@interim_theta_est[position] <- o@initial_theta_est
-      o@interim_se_est[position]    <- NA
+      o@interim_theta_est[position, ] <- o@initial_theta_est
+      o@interim_se_est[position, ]    <- NA
       return(o)
     }
   }
@@ -40,8 +40,8 @@ estimateInterimTheta <- function(
 
     interim_EAP <- computeEAPFromPosterior(augmented_posterior_record$posterior[j, ], constants$theta_q)
     interim_EAP <- applyShrinkageCorrection(interim_EAP, config@interim_theta)
-    o@interim_theta_est[position] <- interim_EAP$theta
-    o@interim_se_est[position]    <- interim_EAP$se
+    o@interim_theta_est[position, ] <- interim_EAP$theta
+    o@interim_se_est[position, ]    <- interim_EAP$se
 
     return(o)
 
@@ -64,8 +64,8 @@ estimateInterimTheta <- function(
       do_Fisher     = config@interim_theta$do_Fisher
     )
 
-    o@interim_theta_est[position] <- interim_MLE$th
-    o@interim_se_est[position]    <- interim_MLE$se
+    o@interim_theta_est[position, ] <- interim_MLE$th
+    o@interim_se_est[position, ]    <- interim_MLE$se
 
     return(o)
 
@@ -90,8 +90,8 @@ estimateInterimTheta <- function(
       do_Fisher        = config@interim_theta$do_Fisher
     )
 
-    o@interim_theta_est[position] <- interim_MLEF$th
-    o@interim_se_est[position]    <- interim_MLEF$se
+    o@interim_theta_est[position, ] <- interim_MLEF$th
+    o@interim_se_est[position, ]    <- interim_MLEF$se
 
     return(o)
 
@@ -113,11 +113,11 @@ estimateInterimTheta <- function(
       model[current_item], 1, c(current_theta$theta, current_theta$se)
     )[, 1]
 
-    interim_EB                    <- applyThin(interim_EB, posterior_constants)
+    interim_EB <- applyThin(interim_EB, posterior_constants)
 
-    o@posterior_sample            <- interim_EB
-    o@interim_theta_est[position] <- mean(interim_EB)
-    o@interim_se_est[position]    <- sd(interim_EB)
+    o@posterior_sample <- interim_EB
+    o@interim_theta_est[position, ] <- mean(interim_EB)
+    o@interim_se_est[position, ]    <- sd(interim_EB)
 
     return(o)
 
@@ -140,11 +140,11 @@ estimateInterimTheta <- function(
       model[current_item], 1, c(current_theta$theta, current_theta$se)
     )[, 1]
 
-    interim_FB                    <- applyThin(interim_FB, posterior_constants)
+    interim_FB <- applyThin(interim_FB, posterior_constants)
 
-    o@posterior_sample            <- interim_FB
-    o@interim_theta_est[position] <- mean(interim_FB)
-    o@interim_se_est[position]    <- sd(interim_FB)
+    o@posterior_sample <- interim_FB
+    o@interim_theta_est[position, ] <- mean(interim_FB)
+    o@interim_se_est[position, ]    <- sd(interim_FB)
 
     return(o)
 
@@ -169,8 +169,8 @@ estimateFinalTheta <- function(
 
     # Skip final theta estimation if methods are identical
 
-    o@final_theta_est <- o@interim_theta_est[position]
-    o@final_se_est    <- o@interim_se_est[position]
+    o@final_theta_est <- o@interim_theta_est[position, ]
+    o@final_se_est    <- o@interim_se_est[position, ]
 
     return(o)
 
@@ -203,7 +203,7 @@ estimateFinalTheta <- function(
         augmented_item_pool,
         select        = c(augment_item_index, o@administered_item_index[1:constants$max_ni]),
         resp          = c(augment_item_resp,  o@administered_item_resp[1:constants$max_ni]),
-        start_theta   = o@interim_theta_est[constants$max_ni],
+        start_theta   = o@interim_theta_est[constants$max_ni, ],
         max_iter      = config@final_theta$max_iter,
         crit          = config@final_theta$crit,
         theta_range   = config@final_theta$bound_ML,
@@ -222,7 +222,7 @@ estimateFinalTheta <- function(
         item_pool,
         select        = o@administered_item_index[1:constants$max_ni],
         resp          = o@administered_item_resp[1:constants$max_ni],
-        start_theta   = o@interim_theta_est[constants$max_ni],
+        start_theta   = o@interim_theta_est[constants$max_ni, ],
         max_iter      = config@final_theta$max_iter,
         crit          = config@final_theta$crit,
         theta_range   = config@final_theta$bound_ML,
@@ -252,7 +252,7 @@ estimateFinalTheta <- function(
         resp             = c(augment_item_resp,  o@administered_item_resp[1:constants$max_ni]),
         fence_slope      = config@final_theta$fence_slope,
         fence_difficulty = config@final_theta$fence_difficulty,
-        start_theta      = o@interim_theta_est[constants$max_ni],
+        start_theta      = o@interim_theta_est[constants$max_ni, ],
         max_iter         = config@final_theta$max_iter,
         crit             = config@final_theta$crit,
         theta_range      = config@final_theta$bound_ML,
@@ -273,7 +273,7 @@ estimateFinalTheta <- function(
         resp             = o@administered_item_resp[1:constants$max_ni],
         fence_slope      = config@final_theta$fence_slope,
         fence_difficulty = config@final_theta$fence_difficulty,
-        start_theta      = o@interim_theta_est[constants$max_ni],
+        start_theta      = o@interim_theta_est[constants$max_ni, ],
         max_iter         = config@final_theta$max_iter,
         crit             = config@final_theta$crit,
         theta_range      = config@final_theta$bound_ML,

--- a/tests/testthat/test-gfi.R
+++ b/tests/testthat/test-gfi.R
@@ -25,7 +25,7 @@ test_that("GFI works", {
 
   for (item_position in 2:30) {
     shadow_test      <- solution@output[[1]]@shadow_test[[item_position]]$i
-    target_theta     <- solution@output[[1]]@interim_theta_est[item_position - 1]
+    target_theta     <- solution@output[[1]]@interim_theta_est[item_position - 1, ]
     shadow_test_info <- calcFisher(itempool_science[shadow_test], target_theta)
     shadow_test_info <- sum(shadow_test_info)
     expect_equal(shadow_test_info, target_value, tolerance = 0.05)

--- a/tests/testthat/test-refresh-methods.R
+++ b/tests/testthat/test-refresh-methods.R
@@ -48,7 +48,7 @@ test_that("refresh methods work", {
   solution  <- Shadow(cfg, constraints_science2, true_theta, data = resp_science)
 
   theta     <- solution@output[[1]]@interim_theta_est
-  delta     <- c(0, 0, abs(theta[2:30] - theta[1:29]))
+  delta     <- c(0, 0, abs(theta[2:30, ] - theta[1:29, ]))
   flag      <- c(delta > .1)[1:30]
   flag[1:2] <- TRUE
 
@@ -66,7 +66,7 @@ test_that("refresh methods work", {
   solution  <- Shadow(cfg, constraints_science2, true_theta, data = resp_science)
 
   theta     <- solution@output[[1]]@interim_theta_est
-  delta     <- c(0, 0, abs(theta[2:30] - theta[1:29]))
+  delta     <- c(0, 0, abs(theta[2:30, ] - theta[1:29, ]))
   flag      <- c(delta > .1)[1:30]
   flag[1:2] <- TRUE
   new_flag  <- rep(FALSE, 30)

--- a/tests/testthat/test-theta-methods.R
+++ b/tests/testthat/test-theta-methods.R
@@ -15,7 +15,7 @@ for (m in methods) {
     )
     set.seed(1)
     solution <- Shadow(cfg, constraints_bayes, true_theta, data = resp_bayes)
-    last_interim_theta <- unlist(lapply(solution@output, function(x) x@interim_theta_est[30]))
+    last_interim_theta <- unlist(lapply(solution@output, function(x) x@interim_theta_est[30, ]))
     fit <- lm(last_interim_theta ~ true_theta)
     expect_gt(coef(fit)[2], 0.7)
 


### PR DESCRIPTION
## Description

- Interim thetas are now internally typecasted to a matrix, with the number of rows being the number of theta values (= test length).
- This was done to prepare for multidimensional cases.