### PR TITLE
fix shrinkage correction

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 * Fixed where `Shadow()` was not working when the `FIXED` item selection method was used with a single `$fixed_theta` value in the config. (#132)
 * Fixed where if interim theta estimation method was `EB` or `FB`, prior sample generation was ignoring prior distribution type and assuming normal distribution.
 * Fixed where if prior distribution type was uniform, prior density generation was ignoring prior parameters and using U(0, 1).
+* Fixed where EAP shrinkage correction was ignoring prior standard deviation when it was supplied in the config.
 
 ## Updates
 

--- a/R/theta_functions.R
+++ b/R/theta_functions.R
@@ -39,7 +39,7 @@ estimateInterimTheta <- function(
   if (toupper(config@interim_theta$method) == "EAP") {
 
     interim_EAP <- computeEAPFromPosterior(augmented_posterior_record$posterior[j, ], constants$theta_q)
-    interim_EAP <- applyShrinkageCorrection(interim_EAP, config@interim_theta)
+    interim_EAP <- applyShrinkageCorrection(interim_EAP, config@interim_theta, j)
     o@interim_theta_est[position, ] <- interim_EAP$theta
     o@interim_se_est[position, ]    <- interim_EAP$se
 
@@ -186,7 +186,7 @@ estimateFinalTheta <- function(
 
     o@posterior       <- o@likelihood * final_prior
     final_EAP <- computeEAPFromPosterior(o@posterior, constants$theta_q)
-    final_EAP <- applyShrinkageCorrection(final_EAP, config@final_theta)
+    final_EAP <- applyShrinkageCorrection(final_EAP, config@final_theta, j)
     o@final_theta_est <- final_EAP$theta
     o@final_se_est    <- final_EAP$se
 
@@ -1156,10 +1156,10 @@ computeEAPFromPosterior <- function(posterior, theta_grid) {
 }
 
 #' @noRd
-applyShrinkageCorrection <- function(EAP, config_theta) {
+applyShrinkageCorrection <- function(EAP, config_theta, j) {
 
   if (toupper(config_theta$prior_dist) == "NORMAL" && config_theta$shrinkage_correction) {
-    prior_sd <- config_theta$prior_sd
+    prior_sd <- config_theta$prior_par[[j]][2]
     o        <- list()
     o$theta  <- EAP$theta * (1 + (EAP$se ** 2))
     o$se     <- EAP$se


### PR DESCRIPTION
## Description

- Fixed where EAP shrinkage correction was ignoring prior standard deviation even when it was supplied. This was due to incorrect parsing of the config object; it was attempting to parse `config_theta$prior_sd` which is an unused slot.