### PR TITLE
fix `duplicate item IDs found` warning when using `MLEF` for R <= 3.6

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 * Fixed where if interim theta estimation method was `EB` or `FB`, prior sample generation was ignoring prior distribution type and assuming normal distribution.
 * Fixed where if prior distribution type was uniform, prior density generation was ignoring prior parameters and using U(0, 1).
 * Fixed where EAP shrinkage correction was ignoring prior standard deviation when it was supplied in the config.
+* Fixed where using MLEF would raise a `duplicate item IDs found` warning for R <= 3.6.
 
 ## Updates
 

--- a/R/theta_functions.R
+++ b/R/theta_functions.R
@@ -776,7 +776,8 @@ setMethod(
           ID    = c("FENCE_LB", "FENCE_UB"),
           MODEL = rep("2PL", 2),
           PAR1  = rep(fence_slope, length.out = 2),
-          PAR2  = fence_difficulty
+          PAR2  = fence_difficulty,
+          stringsAsFactors = FALSE
         )
         item_fence <- loadItemPool(ipar_fence)
         object     <- object + item_fence


### PR DESCRIPTION
## Description

- Fixed #143
- The cause of the bug was that `ipar_fence$ID` created inside `mlef()` was being typecasted to a factor, a default behavior in R <= 3.6.