### PR TITLE
refactor the use of posterior density vector in theta estimation logic

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# TestDesign 1.3.4.9000
+
+## Bug fixes
+
+* Fixed where using `include_items_for_estimation` argument of `Shadow()` was not being reflected in the initial theta estimate.
+
 # TestDesign 1.3.4
 
 ## Bug fixes

--- a/R/bayes_functions.R
+++ b/R/bayes_functions.R
@@ -286,15 +286,3 @@ getSegmentProb <- function(posterior_sample, constants) {
   return(segment_prob)
 
 }
-
-#' @noRd
-updatePosterior <- function(posterior_record, j, prob_resp) {
-
-  posterior_record$posterior[j, ] <-
-  posterior_record$posterior[j, ] * prob_resp
-  posterior_record$likelihood[j, ] <-
-  posterior_record$likelihood[j, ] * prob_resp
-
-  return(posterior_record)
-
-}

--- a/R/bayes_functions.R
+++ b/R/bayes_functions.R
@@ -55,7 +55,7 @@ initializePosterior <- function(config, constants, item_pool, posterior_constant
 
   o <- list()
 
-  o$likelihood <- rep(1, constants$nq)
+  o$likelihood <- matrix(1, constants$nj, constants$nq)
   o$posterior  <- NULL
 
   o$posterior <- generateDensityFromPriorPar(
@@ -316,8 +316,8 @@ updatePosterior <- function(posterior_record, j, prob_resp) {
 
   posterior_record$posterior[j, ] <-
   posterior_record$posterior[j, ] * prob_resp
-  posterior_record$likelihood     <-
-  posterior_record$likelihood     * prob_resp
+  posterior_record$likelihood[j, ] <-
+  posterior_record$likelihood[j, ] * prob_resp
 
   return(posterior_record)
 

--- a/R/bayes_functions.R
+++ b/R/bayes_functions.R
@@ -200,6 +200,21 @@ logitHyperPars <- function(mean, sd) {
 }
 
 #' @noRd
+generateItemParameterSample <- function(config, item_pool, posterior_constants) {
+
+  o <- NULL
+
+  interim_method <- toupper(config@interim_theta$method)
+  final_method   <- toupper(config@final_theta$method)
+  if (any(c(interim_method, final_method) %in% c("FB"))) {
+    o <- iparPosteriorSample(item_pool, posterior_constants$n_sample)
+  }
+
+  return(o)
+
+}
+
+#' @noRd
 generateDensityFromPriorPar <- function(config_theta, theta_q, nj) {
 
   nq <- nrow(theta_q)

--- a/R/bayes_functions.R
+++ b/R/bayes_functions.R
@@ -51,30 +51,6 @@ parsePriorParameters <- function(o, constants, prior_density_override, prior_par
 }
 
 #' @noRd
-initializePosterior <- function(config, constants, item_pool, posterior_constants) {
-
-  o <- list()
-
-  o$likelihood <- matrix(1, constants$nj, constants$nq)
-  o$posterior  <- NULL
-
-  o$posterior <- generateDensityFromPriorPar(
-    config@interim_theta,
-    constants$theta_q,
-    constants$nj
-  )
-
-  interim_method <- toupper(config@interim_theta$method)
-  final_method   <- toupper(config@final_theta$method)
-  if (any(c(interim_method, final_method) %in% c("FB"))) {
-    o$ipar_list <- iparPosteriorSample(item_pool, posterior_constants$n_sample)
-  }
-
-  return(o)
-
-}
-
-#' @noRd
 getPosteriorConstants <- function(config) {
 
   o <- list()

--- a/R/other_functions.R
+++ b/R/other_functions.R
@@ -164,10 +164,14 @@ getInfoFixedTheta <- function(item_selection, constants, item_pool, model) {
 
 #' @noRd
 computeInfoAtCurrentTheta <- function(
-  item_selection, j,
-  current_theta, item_pool, model_code,
+  item_selection,
+  j,
+  current_theta,
+  item_pool,
+  model_code,
   info_fixed_theta,
-  info_grid
+  info_grid,
+  item_parameter_sample
 ) {
 
   item_method <- toupper(item_selection$method)
@@ -198,13 +202,13 @@ computeInfoAtCurrentTheta <- function(
   if (item_method == "FB" & info_type == "FISHER") {
     info <- calc_info_FB(
       matrix(current_theta$posterior_sample),
-      current_theta$ipar_list, item_pool@NCAT, model_code)[, 1]
+      item_parameter_sample, item_pool@NCAT, model_code)[, 1]
     return(info)
   }
   if (item_method == "FB" & info_type %in% c("MI", "MUTUAL")) {
     info <- calc_MI_FB(
       matrix(current_theta$posterior_sample),
-      current_theta$ipar_list, item_pool@NCAT, model_code)[, 1]
+      item_parameter_sample, item_pool@NCAT, model_code)[, 1]
     return(info)
   }
 }

--- a/R/other_functions.R
+++ b/R/other_functions.R
@@ -165,7 +165,7 @@ getInfoFixedTheta <- function(item_selection, constants, item_pool, model) {
 #' @noRd
 computeInfoAtCurrentTheta <- function(
   item_selection, j,
-  current_theta, item_pool, model_code, posterior_record,
+  current_theta, item_pool, model_code,
   info_fixed_theta,
   info_grid
 ) {
@@ -186,7 +186,7 @@ computeInfoAtCurrentTheta <- function(
     return(info)
   }
   if (item_method == "MPWI") {
-    info <- as.vector(matrix(posterior_record$posterior[j, ], nrow = 1) %*% info_grid)
+    info <- as.vector(matrix(current_theta$posterior, nrow = 1) %*% info_grid)
     return(info)
   }
   if (item_method == "EB") {
@@ -198,13 +198,13 @@ computeInfoAtCurrentTheta <- function(
   if (item_method == "FB" & info_type == "FISHER") {
     info <- calc_info_FB(
       matrix(current_theta$posterior_sample),
-      posterior_record$ipar_list, item_pool@NCAT, model_code)[, 1]
+      current_theta$ipar_list, item_pool@NCAT, model_code)[, 1]
     return(info)
   }
   if (item_method == "FB" & info_type %in% c("MI", "MUTUAL")) {
     info <- calc_MI_FB(
       matrix(current_theta$posterior_sample),
-      posterior_record$ipar_list, item_pool@NCAT, model_code)[, 1]
+      current_theta$ipar_list, item_pool@NCAT, model_code)[, 1]
     return(info)
   }
 }

--- a/R/other_functions.R
+++ b/R/other_functions.R
@@ -165,7 +165,7 @@ getInfoFixedTheta <- function(item_selection, constants, item_pool, model) {
 #' @noRd
 computeInfoAtCurrentTheta <- function(
   item_selection, j,
-  current_theta, item_pool, model, posterior_record,
+  current_theta, item_pool, model_code, posterior_record,
   info_fixed_theta,
   info_grid
 ) {
@@ -178,11 +178,11 @@ computeInfoAtCurrentTheta <- function(
     return(info)
   }
   if (item_method == "MFI") {
-    info <- calc_info(current_theta$theta, item_pool@ipar, item_pool@NCAT, model)
+    info <- calc_info(current_theta$theta, item_pool@ipar, item_pool@NCAT, model_code)
     return(info)
   }
   if (item_method == "GFI") {
-    info <- calc_info(current_theta$theta, item_pool@ipar, item_pool@NCAT, model)
+    info <- calc_info(current_theta$theta, item_pool@ipar, item_pool@NCAT, model_code)
     return(info)
   }
   if (item_method == "MPWI") {
@@ -192,19 +192,19 @@ computeInfoAtCurrentTheta <- function(
   if (item_method == "EB") {
     info <- calc_info_EB(
       matrix(current_theta$posterior_sample),
-      item_pool@ipar, item_pool@NCAT, model)[, 1]
+      item_pool@ipar, item_pool@NCAT, model_code)[, 1]
     return(info)
   }
   if (item_method == "FB" & info_type == "FISHER") {
     info <- calc_info_FB(
       matrix(current_theta$posterior_sample),
-      posterior_record$ipar_list, item_pool@NCAT, model)[, 1]
+      posterior_record$ipar_list, item_pool@NCAT, model_code)[, 1]
     return(info)
   }
   if (item_method == "FB" & info_type %in% c("MI", "MUTUAL")) {
     info <- calc_MI_FB(
       matrix(current_theta$posterior_sample),
-      posterior_record$ipar_list, item_pool@NCAT, model)[, 1]
+      posterior_record$ipar_list, item_pool@NCAT, model_code)[, 1]
     return(info)
   }
 }

--- a/R/shadow_functions.R
+++ b/R/shadow_functions.R
@@ -384,8 +384,8 @@ setMethod(
 
         if (position == constants$max_ni) {
           done <- TRUE
-          o@likelihood <- posterior_record$likelihood[j, ]
-          o@posterior  <- posterior_record$posterior[j, ]
+          o@likelihood <- current_theta$likelihood
+          o@posterior  <- current_theta$posterior
         }
 
         if (has_progress_pkg) {

--- a/R/shadow_functions.R
+++ b/R/shadow_functions.R
@@ -208,7 +208,6 @@ setMethod(
           current_theta,
           item_pool,
           model_code,
-          posterior_record,
           info_fixed_theta,               # Only used if config@item_selection$method = "FIXED"
           simulation_data_cache@info_grid # Only used if config@item_selection$method = "MPWI"
         )

--- a/R/shadow_functions.R
+++ b/R/shadow_functions.R
@@ -324,7 +324,7 @@ setMethod(
 
         prob_matrix_current_item <- simulation_data_cache@prob_grid[[o@administered_item_index[position]]]
         prob_resp_current_item   <- prob_matrix_current_item[, o@administered_item_resp[position] + 1]
-        posterior_record <- updatePosterior(posterior_record, j, prob_resp_current_item)
+        current_theta <- updateThetaPosterior(current_theta, prob_resp_current_item)
 
         # Item position / simulee: utilize supplied items if necessary
 

--- a/R/shadow_functions.R
+++ b/R/shadow_functions.R
@@ -75,7 +75,7 @@ setMethod(
     }
 
     item_pool             <- constraints@pool
-    model                 <- sanitizeModel(item_pool@model)
+    model_code            <- sanitizeModel(item_pool@model)
     simulation_data_cache <- makeSimulationDataCache(
       item_pool = item_pool,
       info_type = "FISHER",
@@ -92,7 +92,7 @@ setMethod(
     exclude_index         <- getIndexOfExcludedEntry(exclude, constraints)
 
     # Only used if config@item_selection$method = "FIXED"
-    info_fixed_theta      <- getInfoFixedTheta(config@item_selection, constants, item_pool, model)
+    info_fixed_theta      <- getInfoFixedTheta(config@item_selection, constants, item_pool, model_code)
 
     if (constants$use_shadowtest) {
       shadowtest_refresh_schedule <- parseShadowTestRefreshSchedule(constants, config@refresh_policy)
@@ -207,7 +207,7 @@ setMethod(
           config@item_selection, j,
           current_theta,
           item_pool,
-          model,
+          model_code,
           posterior_record,
           info_fixed_theta,               # Only used if config@item_selection$method = "FIXED"
           simulation_data_cache@info_grid # Only used if config@item_selection$method = "MPWI"
@@ -366,7 +366,7 @@ setMethod(
           o, j, position,
           current_theta,
           augmented_posterior_record, posterior_record,
-          augmented_item_pool, item_pool, model,
+          augmented_item_pool, item_pool, model_code,
           augmented_item_index,
           augmented_item_resp,
           include_items_for_estimation,
@@ -397,7 +397,7 @@ setMethod(
       # Simulee: test complete, estimate theta
       o <- estimateFinalTheta(
         o, j, position,
-        augmented_item_pool, item_pool, model,
+        augmented_item_pool, item_pool, model_code,
         augment_item_index,
         augment_item_resp,
         include_items_for_estimation,

--- a/R/shadow_functions.R
+++ b/R/shadow_functions.R
@@ -156,7 +156,7 @@ setMethod(
       o@set_based                   <- constants$set_based
       o@item_index_by_stimulus      <- constraints@item_index_by_stimulus
 
-      current_theta <- parseInitialTheta(
+      current_theta <- parseInitialThetaOfThisExaminee(
         config@interim_theta,
         initial_theta,
         j,

--- a/R/shadow_functions.R
+++ b/R/shadow_functions.R
@@ -346,14 +346,14 @@ setMethod(
           )
           prob_resp_supplied_items <- apply(prob_resp_supplied_items, 1, prod)
 
-          augmented_posterior_record <- updatePosterior(posterior_record, j, prob_resp_supplied_items)
+          augmented_current_theta    <- updateThetaPosterior(current_theta, prob_resp_supplied_items)
           augmented_item_pool        <- augmented_item_pool
           augmented_item_index       <- c(augment_item_index, o@administered_item_index[1:position])
           augmented_item_resp        <- c(augment_item_resp,  o@administered_item_resp[1:position])
 
         } else {
 
-          augmented_posterior_record <- posterior_record
+          augmented_current_theta    <- current_theta
           augmented_item_pool        <- item_pool
           augmented_item_index       <- o@administered_item_index[1:position]
           augmented_item_resp        <- o@administered_item_resp[1:position]

--- a/R/shadow_functions.R
+++ b/R/shadow_functions.R
@@ -89,6 +89,7 @@ setMethod(
     config@final_theta    <- parsePriorParameters(config@final_theta  , constants, prior, prior_par)
     posterior_constants   <- getPosteriorConstants(config)
     initial_theta         <- parseInitialTheta(config, constants, item_pool, posterior_constants)
+    item_parameter_sample <- generateItemParameterSample(config, item_pool, posterior_constants)
     exclude_index         <- getIndexOfExcludedEntry(exclude, constraints)
 
     # Only used if config@item_selection$method = "FIXED"
@@ -204,12 +205,14 @@ setMethod(
 
         position <- position + 1
         info_current_theta <- computeInfoAtCurrentTheta(
-          config@item_selection, j,
+          config@item_selection,
+          j,
           current_theta,
           item_pool,
           model_code,
-          info_fixed_theta,               # Only used if config@item_selection$method = "FIXED"
-          simulation_data_cache@info_grid # Only used if config@item_selection$method = "MPWI"
+          info_fixed_theta,                # Only used if config@item_selection$method = "FIXED"
+          simulation_data_cache@info_grid, # Only used if config@item_selection$method = "MPWI"
+          item_parameter_sample            # Only used if config@item_selection$method = "FB"
         )
 
         # Item position / simulee: do shadow test assembly
@@ -368,7 +371,7 @@ setMethod(
           augmented_item_index,
           augmented_item_resp,
           include_items_for_estimation,
-          augmented_current_theta$ipar_list, # TODO: needs to be changed to its own variable
+          item_parameter_sample,
           config,
           constants,
           posterior_constants
@@ -401,7 +404,7 @@ setMethod(
         augmented_item_index,
         augmented_item_resp,
         include_items_for_estimation,
-        current_theta$ipar_list, # TODO: needs to be changed to its own variable
+        item_parameter_sample,
         config,
         constants,
         posterior_constants

--- a/R/shadow_functions.R
+++ b/R/shadow_functions.R
@@ -89,7 +89,7 @@ setMethod(
     config@final_theta    <- parsePriorParameters(config@final_theta  , constants, prior, prior_par)
     posterior_constants   <- getPosteriorConstants(config)
     posterior_record      <- initializePosterior(config, constants, item_pool, posterior_constants)
-    initial_theta         <- initializeTheta(config, constants, posterior_record)
+    initial_theta         <- parseInitialTheta(config, constants, posterior_record)
     exclude_index         <- getIndexOfExcludedEntry(exclude, constraints)
 
     # Only used if config@item_selection$method = "FIXED"

--- a/R/shadow_functions.R
+++ b/R/shadow_functions.R
@@ -140,7 +140,7 @@ setMethod(
         o@true_theta <- true_theta[j, ]
       }
 
-      o@prior <- posterior_record$posterior[j, ]
+      o@prior <- initial_theta$posterior[j, ]
       o@administered_item_index     <- rep(NA_real_, constants$max_ni)
       o@administered_item_resp      <- rep(NA_real_, constants$max_ni)
       o@administered_stimulus_index <- NaN

--- a/R/shadow_functions.R
+++ b/R/shadow_functions.R
@@ -364,12 +364,12 @@ setMethod(
         # Item position / simulee: estimate theta
         o <- estimateInterimTheta(
           o, j, position,
-          current_theta,
-          augmented_posterior_record, posterior_record,
+          augmented_current_theta,
           augmented_item_pool, model_code,
           augmented_item_index,
           augmented_item_resp,
           include_items_for_estimation,
+          augmented_current_theta$ipar_list, # TODO: needs to be changed to its own variable
           config,
           constants,
           posterior_constants

--- a/R/shadow_functions.R
+++ b/R/shadow_functions.R
@@ -397,11 +397,12 @@ setMethod(
       # Simulee: test complete, estimate theta
       o <- estimateFinalTheta(
         o, j, position,
-        augmented_item_pool, item_pool, model_code,
-        augment_item_index,
-        augment_item_resp,
+        augmented_item_pool,
+        model_code,
+        augmented_item_index,
+        augmented_item_resp,
         include_items_for_estimation,
-        posterior_record,
+        current_theta$ipar_list, # TODO: needs to be changed to its own variable
         config,
         constants,
         posterior_constants

--- a/R/shadow_functions.R
+++ b/R/shadow_functions.R
@@ -88,7 +88,7 @@ setMethod(
     config@interim_theta  <- parsePriorParameters(config@interim_theta, constants, prior, prior_par)
     config@final_theta    <- parsePriorParameters(config@final_theta  , constants, prior, prior_par)
     posterior_constants   <- getPosteriorConstants(config)
-    initial_theta         <- parseInitialTheta(config, constants, item_pool, posterior_constants)
+    initial_theta         <- parseInitialTheta(config, constants, item_pool, posterior_constants, include_items_for_estimation)
     item_parameter_sample <- generateItemParameterSample(config, item_pool, posterior_constants)
     exclude_index         <- getIndexOfExcludedEntry(exclude, constraints)
 
@@ -156,6 +156,7 @@ setMethod(
       o@set_based                   <- constants$set_based
       o@item_index_by_stimulus      <- constraints@item_index_by_stimulus
 
+      # Simulee: initialize theta estimate
       current_theta <- parseInitialThetaOfThisExaminee(
         config@interim_theta,
         initial_theta,
@@ -332,23 +333,7 @@ setMethod(
 
         if (!is.null(include_items_for_estimation)) {
 
-          prob_matrix_supplied_items <- calcProb(
-            include_items_for_estimation[[j]]$administered_item_pool,
-            constants$theta_q
-          )
-
-          n_supplied_items <- include_items_for_estimation[[j]]$administered_item_pool@ni
-
-          prob_resp_supplied_items <- sapply(
-            1:n_supplied_items,
-            function(i) {
-              resp <- include_items_for_estimation[[j]]$administered_item_resp[i] + 1
-              prob_matrix_supplied_items[[i]][, resp]
-            }
-          )
-          prob_resp_supplied_items <- apply(prob_resp_supplied_items, 1, prod)
-
-          augmented_current_theta    <- updateThetaPosterior(current_theta, prob_resp_supplied_items)
+          augmented_current_theta    <- current_theta
           augmented_item_pool        <- augmented_item_pool
           augmented_item_index       <- c(augment_item_index, o@administered_item_index[1:position])
           augmented_item_resp        <- c(augment_item_resp,  o@administered_item_resp[1:position])

--- a/R/shadow_functions.R
+++ b/R/shadow_functions.R
@@ -178,8 +178,6 @@ setMethod(
         o@shadow_test_refreshed <- logical(constants$test_length)
       }
 
-      posterior_record$likelihood <- rep(1, constants$nq)
-
       theta_change <- 10000
       done         <- FALSE
       position     <- 0
@@ -387,7 +385,7 @@ setMethod(
 
         if (position == constants$max_ni) {
           done <- TRUE
-          o@likelihood <- posterior_record$likelihood
+          o@likelihood <- posterior_record$likelihood[j, ]
           o@posterior  <- posterior_record$posterior[j, ]
         }
 

--- a/R/shadow_functions.R
+++ b/R/shadow_functions.R
@@ -366,7 +366,7 @@ setMethod(
           o, j, position,
           current_theta,
           augmented_posterior_record, posterior_record,
-          augmented_item_pool, item_pool, model_code,
+          augmented_item_pool, model_code,
           augmented_item_index,
           augmented_item_resp,
           include_items_for_estimation,

--- a/R/shadow_functions.R
+++ b/R/shadow_functions.R
@@ -88,8 +88,7 @@ setMethod(
     config@interim_theta  <- parsePriorParameters(config@interim_theta, constants, prior, prior_par)
     config@final_theta    <- parsePriorParameters(config@final_theta  , constants, prior, prior_par)
     posterior_constants   <- getPosteriorConstants(config)
-    posterior_record      <- initializePosterior(config, constants, item_pool, posterior_constants)
-    initial_theta         <- parseInitialTheta(config, constants, posterior_record)
+    initial_theta         <- parseInitialTheta(config, constants, item_pool, posterior_constants)
     exclude_index         <- getIndexOfExcludedEntry(exclude, constraints)
 
     # Only used if config@item_selection$method = "FIXED"

--- a/R/theta_functions.R
+++ b/R/theta_functions.R
@@ -1097,7 +1097,7 @@ getInitialThetaPrior <- function(config_theta, j, posterior_constants) {
 }
 
 #' @noRd
-parseInitialTheta <- function(config_theta, initial_theta, j, posterior_constants) {
+parseInitialThetaOfThisExaminee <- function(config_theta, initial_theta, j, posterior_constants) {
 
   o <- list()
   theta_method <- toupper(config_theta$method)

--- a/R/theta_functions.R
+++ b/R/theta_functions.R
@@ -1055,7 +1055,7 @@ setMethod(
 )
 
 #' @noRd
-initializeTheta <- function(config, constants, posterior_record) {
+parseInitialTheta <- function(config, constants, posterior_record) {
   nj <- constants$nj
   config_value <- config@item_selection$initial_theta
   if (!is.null(config_value)) {

--- a/R/theta_functions.R
+++ b/R/theta_functions.R
@@ -1050,13 +1050,6 @@ parseInitialTheta <- function(config, constants, item_pool, posterior_constants)
     constants$nj
   )
 
-  interim_method <- toupper(config@interim_theta$method)
-  final_method   <- toupper(config@final_theta$method)
-  if (any(c(interim_method, final_method) %in% c("FB"))) {
-    o$ipar_list <- iparPosteriorSample(item_pool, posterior_constants$n_sample)
-    # TODO: needs to be migrated to its own function
-  }
-
   config_value <- config@item_selection$initial_theta
 
   if (!is.null(config_value)) {

--- a/R/theta_functions.R
+++ b/R/theta_functions.R
@@ -1050,6 +1050,8 @@ parseInitialTheta <- function(config, constants, item_pool, posterior_constants,
     constants$nj
   )
 
+  o$theta_q <- constants$theta_q
+
   # update likelihood and posterior using include_items_for_estimation
 
   if (!is.null(include_items_for_estimation)) {

--- a/R/theta_functions.R
+++ b/R/theta_functions.R
@@ -6,7 +6,7 @@ estimateInterimTheta <- function(
   o, j, position,
   current_theta,
   augmented_posterior_record, posterior_record,
-  augmented_item_pool, item_pool, model_code,
+  augmented_item_pool, model_code,
   augmented_item_index,
   augmented_item_resp,
   include_items_for_estimation,
@@ -108,8 +108,8 @@ estimateInterimTheta <- function(
 
     interim_EB <- theta_EB_single(
       posterior_constants$n_sample, current_theta$theta, current_theta$se,
-      item_pool@ipar[current_item, ],
-      o@administered_item_resp[position], item_pool@NCAT[current_item],
+      augmented_item_pool@ipar[current_item, ],
+      o@administered_item_resp[position], augmented_item_pool@NCAT[current_item],
       model_code[current_item], 1, c(current_theta$theta, current_theta$se)
     )[, 1]
 
@@ -135,8 +135,8 @@ estimateInterimTheta <- function(
     interim_FB <- theta_FB_single(
       posterior_constants$n_sample, current_theta$theta, current_theta$se,
       posterior_record$ipar_list[[current_item]],
-      item_pool@ipar[current_item, ],
-      o@administered_item_resp[position], item_pool@NCAT[current_item],
+      augmented_item_pool@ipar[current_item, ],
+      o@administered_item_resp[position], augmented_item_pool@NCAT[current_item],
       model_code[current_item], 1, c(current_theta$theta, current_theta$se)
     )[, 1]
 

--- a/R/theta_functions.R
+++ b/R/theta_functions.R
@@ -1120,7 +1120,7 @@ parseInitialThetaOfThisExaminee <- function(config_theta, initial_theta, j, post
   o <- list()
   theta_method <- toupper(config_theta$method)
   if (theta_method %in% c("EAP", "MLE", "MLEF")) {
-    o$theta <- initial_theta[j, ]
+    o$theta <- initial_theta$theta[j, ]
   }
   if (theta_method %in% c("EB", "FB")) {
     o <- getInitialThetaPrior(config_theta, j, posterior_constants)

--- a/R/theta_functions.R
+++ b/R/theta_functions.R
@@ -1093,7 +1093,7 @@ parseInitialTheta <- function(config, constants, item_pool, posterior_constants,
     }
   }
   if (is.null(config_value)) {
-    o$theta <- o$posterior %*% constants$theta_q
+    o$theta <- (o$posterior %*% constants$theta_q) / apply(o$posterior, 1, sum)
   }
 
   return(o)

--- a/R/theta_functions.R
+++ b/R/theta_functions.R
@@ -1171,6 +1171,18 @@ isFirstSegmentValid <- function(first_segment, n_segment, position) {
 }
 
 #' @noRd
+updateThetaPosterior <- function(o, prob_resp) {
+
+  o$posterior <-
+  o$posterior * prob_resp
+  o$likelihood <-
+  o$likelihood * prob_resp
+
+  return(o)
+
+}
+
+#' @noRd
 computeEAPFromPosterior <- function(posterior, theta_grid) {
   o <- list()
   o$theta <- sum(posterior * theta_grid) / sum(posterior)

--- a/R/theta_functions.R
+++ b/R/theta_functions.R
@@ -1103,7 +1103,10 @@ parseInitialThetaOfThisExaminee <- function(config_theta, initial_theta, j, post
     o$theta <- initial_theta$theta[j, ]
   }
   if (theta_method %in% c("EB", "FB")) {
-    o <- getInitialThetaPrior(config_theta, j, posterior_constants)
+    x <- getInitialThetaPrior(config_theta, j, posterior_constants)
+    o$posterior_sample <- x$posterior_sample
+    o$theta            <- x$theta
+    o$se               <- x$se
   }
 
   return(o)

--- a/R/theta_functions.R
+++ b/R/theta_functions.R
@@ -1119,6 +1119,10 @@ parseInitialThetaOfThisExaminee <- function(config_theta, initial_theta, j, post
 
   o <- list()
   theta_method <- toupper(config_theta$method)
+
+  o$likelihood <- initial_theta$likelihood[j, ]
+  o$posterior  <- initial_theta$posterior[j, ]
+
   if (theta_method %in% c("EAP", "MLE", "MLEF")) {
     o$theta <- initial_theta$theta[j, ]
   }

--- a/R/theta_functions.R
+++ b/R/theta_functions.R
@@ -1129,6 +1129,7 @@ parseInitialThetaOfThisExaminee <- function(config_theta, initial_theta, j, post
 
   o$likelihood <- initial_theta$likelihood[j, ]
   o$posterior  <- initial_theta$posterior[j, ]
+  o$theta_q    <- initial_theta$theta_q
 
   if (theta_method %in% c("EAP", "MLE", "MLEF")) {
     o$theta <- initial_theta$theta[j, ]

--- a/R/theta_functions.R
+++ b/R/theta_functions.R
@@ -9,7 +9,7 @@ estimateInterimTheta <- function(
   augmented_item_index,
   augmented_item_resp,
   include_items_for_estimation,
-  ipar_sample_list,
+  item_parameter_sample, # only used for FB
   config,
   constants,
   posterior_constants
@@ -141,7 +141,7 @@ estimateInterimTheta <- function(
       posterior_constants$n_sample,
       augmented_current_theta$theta,
       augmented_current_theta$se,
-      ipar_sample_list[[current_item]],
+      item_parameter_sample[[current_item]],
       augmented_item_pool@ipar[current_item, ],
       o@administered_item_resp[position],
       augmented_item_pool@NCAT[current_item],
@@ -170,7 +170,7 @@ estimateFinalTheta <- function(
   augmented_item_index,
   augmented_item_resp,
   include_items_for_estimation,
-  ipar_sample_list,
+  item_parameter_sample, # only used for FB
   config,
   constants,
   posterior_constants
@@ -308,7 +308,7 @@ estimateFinalTheta <- function(
       posterior_constants$n_sample,
       final_prior$theta,
       final_prior$se,
-      ipar_sample_list[o@administered_item_index[1:position]],
+      item_parameter_sample[o@administered_item_index[1:position]],
       augmented_item_pool@ipar[o@administered_item_index[1:position], ],
       augmented_item_resp,
       augmented_item_pool@NCAT[o@administered_item_index[1:position]],

--- a/R/theta_functions.R
+++ b/R/theta_functions.R
@@ -165,11 +165,12 @@ estimateInterimTheta <- function(
 #' @noRd
 estimateFinalTheta <- function(
   o, j, position,
-  augmented_item_pool, item_pool, model_code,
-  augment_item_index,
-  augment_item_resp,
+  augmented_item_pool,
+  model_code,
+  augmented_item_index,
+  augmented_item_resp,
   include_items_for_estimation,
-  posterior_record,
+  ipar_sample_list,
   config,
   constants,
   posterior_constants
@@ -206,43 +207,20 @@ estimateFinalTheta <- function(
 
   if (toupper(config@final_theta$method) == "MLE") {
 
-    if (!is.null(include_items_for_estimation)) {
-
-      final_MLE <- mle(
-        augmented_item_pool,
-        select        = c(augment_item_index, o@administered_item_index[1:constants$max_ni]),
-        resp          = c(augment_item_resp,  o@administered_item_resp[1:constants$max_ni]),
-        start_theta   = o@interim_theta_est[constants$max_ni, ],
-        max_iter      = config@final_theta$max_iter,
-        crit          = config@final_theta$crit,
-        theta_range   = config@final_theta$bound_ML,
-        truncate      = config@final_theta$truncate_ML,
-        max_change    = config@final_theta$max_change,
-        use_step_size = config@final_theta$use_step_size,
-        step_size     = config@final_theta$step_size,
-        do_Fisher     = config@final_theta$do_Fisher
-      )
-
-    }
-
-    if (is.null(include_items_for_estimation)) {
-
-      final_MLE <- mle(
-        item_pool,
-        select        = o@administered_item_index[1:constants$max_ni],
-        resp          = o@administered_item_resp[1:constants$max_ni],
-        start_theta   = o@interim_theta_est[constants$max_ni, ],
-        max_iter      = config@final_theta$max_iter,
-        crit          = config@final_theta$crit,
-        theta_range   = config@final_theta$bound_ML,
-        truncate      = config@final_theta$truncate_ML,
-        max_change    = config@final_theta$max_change,
-        use_step_size = config@final_theta$use_step_size,
-        step_size     = config@final_theta$step_size,
-        do_Fisher     = config@final_theta$do_Fisher
-      )
-
-    }
+    final_MLE <- mle(
+      augmented_item_pool,
+      select        = augmented_item_index,
+      resp          = augmented_item_resp,
+      start_theta   = o@interim_theta_est[constants$max_ni, ],
+      max_iter      = config@final_theta$max_iter,
+      crit          = config@final_theta$crit,
+      theta_range   = config@final_theta$bound_ML,
+      truncate      = config@final_theta$truncate_ML,
+      max_change    = config@final_theta$max_change,
+      use_step_size = config@final_theta$use_step_size,
+      step_size     = config@final_theta$step_size,
+      do_Fisher     = config@final_theta$do_Fisher
+    )
 
     o@final_theta_est <- final_MLE$th
     o@final_se_est    <- final_MLE$se
@@ -253,47 +231,22 @@ estimateFinalTheta <- function(
 
   if (toupper(config@final_theta$method) == "MLEF") {
 
-    if (!is.null(include_items_for_estimation)) {
-
-      final_MLEF <- mlef(
-        augmented_item_pool,
-        select           = c(augment_item_index, o@administered_item_index[1:constants$max_ni]),
-        resp             = c(augment_item_resp,  o@administered_item_resp[1:constants$max_ni]),
-        fence_slope      = config@final_theta$fence_slope,
-        fence_difficulty = config@final_theta$fence_difficulty,
-        start_theta      = o@interim_theta_est[constants$max_ni, ],
-        max_iter         = config@final_theta$max_iter,
-        crit             = config@final_theta$crit,
-        theta_range      = config@final_theta$bound_ML,
-        truncate         = config@final_theta$truncate_ML,
-        max_change       = config@final_theta$max_change,
-        use_step_size    = config@final_theta$use_step_size,
-        step_size        = config@final_theta$step_size,
-        do_Fisher        = config@final_theta$do_Fisher
-      )
-
-    }
-
-    if (is.null(include_items_for_estimation)) {
-
-      final_MLEF <- mlef(
-        item_pool,
-        select           = o@administered_item_index[1:constants$max_ni],
-        resp             = o@administered_item_resp[1:constants$max_ni],
-        fence_slope      = config@final_theta$fence_slope,
-        fence_difficulty = config@final_theta$fence_difficulty,
-        start_theta      = o@interim_theta_est[constants$max_ni, ],
-        max_iter         = config@final_theta$max_iter,
-        crit             = config@final_theta$crit,
-        theta_range      = config@final_theta$bound_ML,
-        truncate         = config@final_theta$truncate_ML,
-        max_change       = config@final_theta$max_change,
-        use_step_size    = config@final_theta$use_step_size,
-        step_size        = config@final_theta$step_size,
-        do_Fisher        = config@final_theta$do_Fisher
-      )
-
-    }
+    final_MLEF <- mlef(
+      augmented_item_pool,
+      select        = augmented_item_index,
+      resp          = augmented_item_resp,
+      fence_slope      = config@final_theta$fence_slope,
+      fence_difficulty = config@final_theta$fence_difficulty,
+      start_theta      = o@interim_theta_est[constants$max_ni, ],
+      max_iter         = config@final_theta$max_iter,
+      crit             = config@final_theta$crit,
+      theta_range      = config@final_theta$bound_ML,
+      truncate         = config@final_theta$truncate_ML,
+      max_change       = config@final_theta$max_change,
+      use_step_size    = config@final_theta$use_step_size,
+      step_size        = config@final_theta$step_size,
+      do_Fisher        = config@final_theta$do_Fisher
+    )
 
     o@final_theta_est <- final_MLEF$th
     o@final_se_est    <- final_MLEF$se
@@ -304,6 +257,11 @@ estimateFinalTheta <- function(
 
   if (toupper(config@final_theta$method) == "EB") {
 
+    # TODO: needs to work with include_items_for_estimation
+    if (!is.null(include_items_for_estimation)) {
+      stop("EB with include_items_for_estimation is not available")
+    }
+
     final_prior <- getInitialThetaPrior(
       config@final_theta,
       j,
@@ -311,10 +269,15 @@ estimateFinalTheta <- function(
     )
 
     final_EB <- theta_EB(
-      posterior_constants$n_sample, final_prior$theta, final_prior$se,
-      item_pool@ipar[o@administered_item_index[1:position], ],
-      o@administered_item_resp[1:position], item_pool@NCAT[o@administered_item_index[1:position]],
-      model_code[o@administered_item_index[1:position]], 1, c(final_prior$theta, final_prior$se)
+      posterior_constants$n_sample,
+      final_prior$theta,
+      final_prior$se,
+      augmented_item_pool@ipar[o@administered_item_index[1:position], ],
+      augmented_item_resp,
+      augmented_item_pool@NCAT[o@administered_item_index[1:position]],
+      model_code[o@administered_item_index[1:position]],
+      1,
+      c(final_prior$theta, final_prior$se)
     )
 
     final_EB           <- applyThin(final_EB, posterior_constants)
@@ -330,6 +293,11 @@ estimateFinalTheta <- function(
 
   if (toupper(config@final_theta$method) == "FB") {
 
+    # TODO: needs to work with include_items_for_estimation
+    if (!is.null(include_items_for_estimation)) {
+      stop("FB with include_items_for_estimation is not available")
+    }
+
     final_prior <- getInitialThetaPrior(
       config@final_theta,
       j,
@@ -337,11 +305,16 @@ estimateFinalTheta <- function(
     )
 
     final_FB <- theta_FB(
-      posterior_constants$n_sample, final_prior$theta, final_prior$se,
-      posterior_record$ipar_list[o@administered_item_index[1:position]],
-      item_pool@ipar[o@administered_item_index[1:position], ],
-      o@administered_item_resp[1:position], item_pool@NCAT[o@administered_item_index[1:position]],
-      model_code[o@administered_item_index[1:position]], 1, c(final_prior$theta, final_prior$se)
+      posterior_constants$n_sample,
+      final_prior$theta,
+      final_prior$se,
+      ipar_sample_list[o@administered_item_index[1:position]],
+      augmented_item_pool@ipar[o@administered_item_index[1:position], ],
+      augmented_item_resp,
+      augmented_item_pool@NCAT[o@administered_item_index[1:position]],
+      model_code[o@administered_item_index[1:position]],
+      1,
+      c(final_prior$theta, final_prior$se)
     )
 
     final_FB           <- applyThin(final_FB, posterior_constants)

--- a/R/theta_functions.R
+++ b/R/theta_functions.R
@@ -6,7 +6,7 @@ estimateInterimTheta <- function(
   o, j, position,
   current_theta,
   augmented_posterior_record, posterior_record,
-  augmented_item_pool, item_pool, model,
+  augmented_item_pool, item_pool, model_code,
   augmented_item_index,
   augmented_item_resp,
   include_items_for_estimation,
@@ -110,7 +110,7 @@ estimateInterimTheta <- function(
       posterior_constants$n_sample, current_theta$theta, current_theta$se,
       item_pool@ipar[current_item, ],
       o@administered_item_resp[position], item_pool@NCAT[current_item],
-      model[current_item], 1, c(current_theta$theta, current_theta$se)
+      model_code[current_item], 1, c(current_theta$theta, current_theta$se)
     )[, 1]
 
     interim_EB <- applyThin(interim_EB, posterior_constants)
@@ -137,7 +137,7 @@ estimateInterimTheta <- function(
       posterior_record$ipar_list[[current_item]],
       item_pool@ipar[current_item, ],
       o@administered_item_resp[position], item_pool@NCAT[current_item],
-      model[current_item], 1, c(current_theta$theta, current_theta$se)
+      model_code[current_item], 1, c(current_theta$theta, current_theta$se)
     )[, 1]
 
     interim_FB <- applyThin(interim_FB, posterior_constants)
@@ -155,7 +155,7 @@ estimateInterimTheta <- function(
 #' @noRd
 estimateFinalTheta <- function(
   o, j, position,
-  augmented_item_pool, item_pool, model,
+  augmented_item_pool, item_pool, model_code,
   augment_item_index,
   augment_item_resp,
   include_items_for_estimation,
@@ -304,7 +304,7 @@ estimateFinalTheta <- function(
       posterior_constants$n_sample, final_prior$theta, final_prior$se,
       item_pool@ipar[o@administered_item_index[1:position], ],
       o@administered_item_resp[1:position], item_pool@NCAT[o@administered_item_index[1:position]],
-      model[o@administered_item_index[1:position]], 1, c(final_prior$theta, final_prior$se)
+      model_code[o@administered_item_index[1:position]], 1, c(final_prior$theta, final_prior$se)
     )
 
     final_EB           <- applyThin(final_EB, posterior_constants)
@@ -331,7 +331,7 @@ estimateFinalTheta <- function(
       posterior_record$ipar_list[o@administered_item_index[1:position]],
       item_pool@ipar[o@administered_item_index[1:position], ],
       o@administered_item_resp[1:position], item_pool@NCAT[o@administered_item_index[1:position]],
-      model[o@administered_item_index[1:position]], 1, c(final_prior$theta, final_prior$se)
+      model_code[o@administered_item_index[1:position]], 1, c(final_prior$theta, final_prior$se)
     )
 
     final_FB           <- applyThin(final_FB, posterior_constants)

--- a/tests/testthat/test_include_items_for_estimation.R
+++ b/tests/testthat/test_include_items_for_estimation.R
@@ -1,0 +1,36 @@
+test_that("include_items_for_estimation works", {
+
+  skip_on_ci()
+  skip_on_cran()
+
+  include_items_for_estimation <- list()
+  n_examinees <- 20
+  true_theta <- rnorm(n_examinees)
+  for (i in 1:n_examinees) {
+    include_items_for_estimation[[i]] <- list()
+    include_items_for_estimation[[i]]$administered_item_pool <-
+      itempool_science[sample(1:1000, 100)]
+    include_items_for_estimation[[i]]$administered_item_resp <-
+      simResp(
+        include_items_for_estimation[[i]]$administered_item_pool,
+        true_theta[i]
+      )
+  }
+
+  cfg <- createShadowTestConfig()
+  o1 <- Shadow(
+    cfg, constraints_science, true_theta
+  )
+  o2 <- Shadow(
+    cfg, constraints_science, true_theta,
+    include_items_for_estimation = include_items_for_estimation
+  )
+
+  expect_true(all(o2@final_se_est < o1@final_se_est))
+
+  rmse_o1 <- sqrt(mean((o1@final_theta_est - true_theta) ** 2))
+  rmse_o2 <- sqrt(mean((o2@final_theta_est - true_theta) ** 2))
+
+  expect_true(rmse_o2 < rmse_o1)
+
+})


### PR DESCRIPTION
## Description

- fixed #150 
- refactored theta estimation logic to keep track of the posterior/likelihood vectors along with the point estimate
- added codetest for `include_items_for_estimation`

## Comments
- adding error bars for initial theta estimate will be done in a separate PR