### PR TITLE
fix where using `gurobi` version `10.0.0` was raising an 'unused argument' error

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: TestDesign
 Type: Package
 Title: Optimal Test Design Approach to Fixed and Adaptive Test Construction
-Version: 1.3.4.9000
-Date: 2022-07-21
+Version: 1.3.5
+Date: 2022-12-02
 Authors@R: c(
     person("Seung W.", "Choi",
         email = "schoi@austin.utexas.edu",
@@ -44,7 +44,7 @@ Suggests:
     pkgdown,
     pkgload
 LinkingTo: Rcpp, RcppArmadillo
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.2
 Encoding: UTF-8
 LazyData: true
 VignetteBuilder: knitr

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 ## Bug fixes
 
 * Fixed where using `include_items_for_estimation` argument of `Shadow()` was not being reflected in the initial theta estimate.
+* Fixed where using `gurobi` solver would raise an 'unused argument' error.
 
 # TestDesign 1.3.4
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# TestDesign 1.3.4.9000
+# TestDesign 1.3.5
 
 ## Updates
 

--- a/R/solver_functions.R
+++ b/R/solver_functions.R
@@ -307,14 +307,12 @@ runMIP <- function(solver, obj, mat, dir, rhs, maximize, types,
     if (!is.null(gap_limit)) {
       MIP <- gurobi::gurobi(
         model = list(obj = obj, modelsense = ifelse(maximize, "max", "min"), rhs = rhs, sense = constraints_dir, vtype = types, A = mat),
-        params = list(MIPGap = gap_limit, TimeLimit = time_limit, LogToConsole = verbosity),
-        env = NULL
+        params = list(MIPGap = gap_limit, TimeLimit = time_limit, LogToConsole = verbosity)
       )
     } else {
       MIP <- gurobi::gurobi(
         model = list(obj = obj, modelsense = ifelse(maximize, "max", "min"), rhs = rhs, sense = constraints_dir, vtype = types, A = mat),
-        params = list(TimeLimit = time_limit, LogToConsole = verbosity),
-        env = NULL
+        params = list(TimeLimit = time_limit, LogToConsole = verbosity)
       )
     }
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,9 +1,9 @@
-# TestDesign 1.3.4
+# TestDesign 1.3.5
 
 ## Test environments
 
 * Local:
-* * Windows 11 (R 4.2.1)
+* * Windows 11 (R 4.2.2)
 * GitHub Actions:
 * * macOS 12 Monterey (R-release)
 * * macOS 11 Big Sur (R-release)
@@ -27,7 +27,7 @@ Information on obtaining 'gurobi' is described in `DESCRIPTION`.
 
 ## Downstream dependencies
 
-The previous version 'TestDesign' 1.3.3 has 1 downstream dependency: 'maat' 1.1.0
+The previous version 'TestDesign' 1.3.4 has 1 downstream dependency: 'maat' 1.1.0
 
 Downstream dependency was checked using 'revdepcheck' available from https://github.com/r-lib/revdepcheck
 


### PR DESCRIPTION
## Description

- Fixed where `gurobi` version `10.0.0` was raising an 'unused argument' error.
- This error was due to the `env` argument of `gurobi()` being removed in the solver package version `10.0.0`.