### PR TITLE
remove `lpsymphony` support

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -55,7 +55,6 @@ jobs:
             any::mirtCAT
             any::testthat
             any::progress
-            any::lpsymphony
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ Authors@R: c(
 Maintainer: Seung W. Choi <schoi@austin.utexas.edu>
 Description: Uses the optimal test design approach by Birnbaum (1968, ISBN:9781593119348) and
     van der Linden (2018) <doi:10.1201/9781315117430> to construct fixed, adaptive, and parallel tests.
-    Supports the following mixed-integer programming (MIP) solver packages: 'lpsymphony', 'Rsymphony',
+    Supports the following mixed-integer programming (MIP) solver packages: 'Rsymphony',
     'gurobi', 'lpSolve', and 'Rglpk'. The 'gurobi' package is not available from CRAN; see <https://www.gurobi.com/downloads/>.
 URL: https://choi-phd.github.io/TestDesign/ (documentation)
 BugReports: https://github.com/choi-phd/TestDesign/issues/
@@ -25,7 +25,6 @@ biocViews:
 Imports: Rcpp (>= 1.0.0), methods, lpSolve, foreach, logitnorm, crayon
 SystemRequirements: C++11
 Suggests:
-    lpsymphony,
     Rsymphony,
     gurobi,
     Rglpk,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: TestDesign
 Type: Package
 Title: Optimal Test Design Approach to Fixed and Adaptive Test Construction
-Version: 1.3.4.9000
-Date: 2022-07-21
+Version: 1.4.0
+Date: 2022-12-14
 Authors@R: c(
     person("Seung W.", "Choi",
         email = "schoi@austin.utexas.edu",
@@ -43,7 +43,7 @@ Suggests:
     pkgdown,
     pkgload
 LinkingTo: Rcpp, RcppArmadillo
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.2
 Encoding: UTF-8
 LazyData: true
 VignetteBuilder: knitr

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# TestDesign 1.3.4.9000
+# TestDesign 1.4.0
 
 ## Updates
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 
 * Added `detectBestSolver()` for detecting the best available solver on the system.
 * `plot(type = "audit")` now plots the initial theta SE when available.
+* Removed support for the `lpsymphony` solver because of installation issues. Users may use the `Rsymphony` solver as an alternative.
 
 ## Bug fixes
 

--- a/R/import.R
+++ b/R/import.R
@@ -49,7 +49,7 @@ NULL
   }
 
   if (!skip_solver_test) {
-    solver_names <- c("lpSolve", "Rsymphony", "lpsymphony", "gurobi", "Rglpk")
+    solver_names <- c("lpSolve", "Rsymphony", "gurobi", "Rglpk")
     for (s in solver_names) {
       x <- find.package(s, quiet = TRUE)
       if (length(x) > 0) {

--- a/R/partitioning_functions.r
+++ b/R/partitioning_functions.r
@@ -102,7 +102,7 @@ getSetStructureConstraints <- function(constraints) {
 #'
 #' @examples
 #' \dontrun{
-#' config <- createStaticTestConfig(MIP = list(solver = "LPSYMPHONY"))
+#' config <- createStaticTestConfig(MIP = list(solver = "RSYMPHONY"))
 #' constraints <- constraints_science[1:10]
 #'
 #' solution <- Split(config, constraints, n_partition = 4, partition_type = "test"))

--- a/R/shadow_class.R
+++ b/R/shadow_class.R
@@ -109,12 +109,12 @@ setClass("config_Shadow",
   ),
   validity = function(object) {
     err <- NULL
-    if (!toupper(object@MIP$solver) %in% c("LPSYMPHONY", "RSYMPHONY", "LPSOLVE", "GUROBI", "RGLPK")) {
-      msg <- sprintf("config@MIP: unrecognized $solver '%s' (accepts LPSYMPHONY, RSYMPHONY, LPSOLVE, GUROBI, RGLPK)", object@MIP$solver)
+    if (!toupper(object@MIP$solver) %in% c("RSYMPHONY", "LPSOLVE", "GUROBI", "RGLPK")) {
+      msg <- sprintf("config@MIP: unrecognized $solver '%s' (accepts RSYMPHONY, LPSOLVE, GUROBI, RGLPK)", object@MIP$solver)
       err <- c(err, msg)
     }
 
-    for (solver_name in c("gurobi", "Rsymphony", "lpsymphony", "Rglpk")) {
+    for (solver_name in c("gurobi", "Rsymphony", "Rglpk")) {
       if (toupper(object@MIP$solver) == toupper(solver_name)) {
         if (!requireNamespace(solver_name, quietly = TRUE)) {
           msg <- sprintf("config@MIP: could not find the specified solver package '%s'", solver_name)
@@ -250,11 +250,11 @@ setClass("config_Shadow",
 #' }
 #' @param MIP a named list containing solver options.
 #' \itemize{
-#'   \item{\code{solver}} the type of solver. Accepts \code{lpsymphony, Rsymphony, gurobi, lpSolve, Rglpk}. (default = \code{LPSOLVE})
+#'   \item{\code{solver}} the type of solver. Accepts \code{Rsymphony, gurobi, lpSolve, Rglpk}. (default = \code{LPSOLVE})
 #'   \item{\code{verbosity}} verbosity level of the solver. (default = \code{-2})
-#'   \item{\code{time_limit}} time limit in seconds. Used in solvers \code{lpsymphony, Rsymphony, gurobi, Rglpk}. (default = \code{60})
+#'   \item{\code{time_limit}} time limit in seconds. Used in solvers \code{Rsymphony, gurobi, Rglpk}. (default = \code{60})
 #'   \item{\code{gap_limit}} search termination criterion. Gap limit in relative scale passed onto the solver. Used in solver \code{gurobi}. (default = \code{.05})
-#'   \item{\code{gap_limit_abs}} search termination criterion. Gap limit in absolute scale passed onto the solver. Used in solvers \code{lpsymphony, Rsymphony}. (default = \code{0.05})
+#'   \item{\code{gap_limit_abs}} search termination criterion. Gap limit in absolute scale passed onto the solver. Used in solvers \code{Rsymphony}. (default = \code{0.05})
 #'   \item{\code{obj_tol}} search termination criterion. The lower bound to use on the minimax deviation variable. Used when \code{item_selection$method} is \code{GFI}, and ignored otherwise. (default = \code{0.05})
 #'   \item{\code{retry}} number of times to retry running the solver if the solver returns no solution. Some solvers incorrectly return no solution even when a solution exists. This is the number of attempts to verify that the problem is indeed infeasible in such cases. Set to \code{0} to not retry. (default = \code{5})
 #' }

--- a/R/solver_functions.R
+++ b/R/solver_functions.R
@@ -258,26 +258,7 @@ runAssembly <- function(config, constraints, xdata = NULL, objective = NULL) {
 runMIP <- function(solver, obj, mat, dir, rhs, maximize, types,
                    verbosity, time_limit, gap_limit_abs, gap_limit) {
 
-  if (solver == "LPSYMPHONY") {
-
-    if (!is.null(gap_limit_abs)) {
-      MIP <- lpsymphony::lpsymphony_solve_LP(
-        obj, mat, dir, rhs,
-        max = maximize, types = types,
-        verbosity = verbosity,
-        time_limit = time_limit,
-        gap_limit = gap_limit_abs
-      )
-    } else {
-      MIP <- lpsymphony::lpsymphony_solve_LP(
-        obj, mat, dir, rhs,
-        max = maximize, types = types,
-        verbosity = verbosity,
-        time_limit = time_limit
-      )
-    }
-
-  } else if (solver == "RSYMPHONY") {
+  if (solver == "RSYMPHONY") {
 
     if (!is.null(gap_limit_abs)) {
       MIP <- Rsymphony::Rsymphony_solve_LP(
@@ -338,9 +319,7 @@ runMIP <- function(solver, obj, mat, dir, rhs, maximize, types,
 #' @noRd
 isOptimal <- function(status, solver) {
   is_optimal <- FALSE
-  if (toupper(solver) == "LPSYMPHONY") {
-    is_optimal <- names(status) %in% c("TM_OPTIMAL_SOLUTION_FOUND", "PREP_OPTIMAL_SOLUTION_FOUND", "TM_TARGET_GAP_ACHIEVED")
-  } else if (toupper(solver) == "RSYMPHONY") {
+  if (toupper(solver) == "RSYMPHONY") {
     is_optimal <- names(status) %in% c("TM_OPTIMAL_SOLUTION_FOUND", "PREP_OPTIMAL_SOLUTION_FOUND", "TM_TARGET_GAP_ACHIEVED")
   } else if (toupper(solver) == "GUROBI") {
     is_optimal <- status %in% c("OPTIMAL")
@@ -354,9 +333,7 @@ isOptimal <- function(status, solver) {
 
 #' @noRd
 getSolverStatusMessage <- function(status, solver) {
-  if (toupper(solver) == "LPSYMPHONY") {
-    tmp <- sprintf("MIP solver returned non-zero status: %s", names(status))
-  } else if (toupper(solver) == "RSYMPHONY") {
+  if (toupper(solver) == "RSYMPHONY") {
     tmp <- sprintf("MIP solver returned non-zero status: %s", names(status))
   } else if (toupper(solver) == "GUROBI") {
     tmp <- sprintf("MIP solver returned non-zero status: %s", status)
@@ -370,9 +347,7 @@ getSolverStatusMessage <- function(status, solver) {
 
 #' @noRd
 printSolverNewline <- function(solver) {
-  if (toupper(solver) == "LPSYMPHONY") {
-    cat("\n")
-  } else if (toupper(solver) == "RSYMPHONY") {
+  if (toupper(solver) == "RSYMPHONY") {
     cat("\n")
   }
 }
@@ -381,12 +356,12 @@ printSolverNewline <- function(solver) {
 validateSolver <- function(config, constraints, purpose = NULL) {
 
   if (constraints@set_based) {
-    if (!toupper(config@MIP$solver) %in%  c("LPSYMPHONY", "RSYMPHONY", "GUROBI")) {
+    if (!toupper(config@MIP$solver) %in%  c("RSYMPHONY", "GUROBI")) {
 
       if (!interactive()) {
         txt <- paste(
           sprintf("Set-based assembly with %s is not allowed in non-interactive mode", config@MIP$solver),
-          "(allowed solvers: LPSYMPHONY, RSYMPHONY, or GUROBI)",
+          "(allowed solvers: RSYMPHONY, or GUROBI)",
           sep = " "
         )
         warning(txt)
@@ -395,7 +370,7 @@ validateSolver <- function(config, constraints, purpose = NULL) {
 
       txt <- paste(
         sprintf("Set-based assembly with %s takes a long time.", config@MIP$solver),
-        "Recommended solvers: LPSYMPHONY, RSYMPHONY, or GUROBI",
+        "Recommended solvers: RSYMPHONY, or GUROBI",
         sep = "\n"
       )
 
@@ -415,12 +390,12 @@ validateSolver <- function(config, constraints, purpose = NULL) {
   }
 
   if (purpose == "SPLIT") {
-    if (!toupper(config@MIP$solver) %in%  c("LPSYMPHONY", "RSYMPHONY", "GUROBI")) {
+    if (!toupper(config@MIP$solver) %in%  c("RSYMPHONY", "GUROBI")) {
 
       if (!interactive()) {
         txt <- paste(
           sprintf("Split() with %s is not allowed in non-interactive mode", config@MIP$solver),
-          "(allowed solvers: LPSYMPHONY, RSYMPHONY, or GUROBI)",
+          "(allowed solvers: RSYMPHONY, or GUROBI)",
           sep = " "
         )
         warning(txt)
@@ -429,7 +404,7 @@ validateSolver <- function(config, constraints, purpose = NULL) {
 
       txt <- paste(
         sprintf("Split() with %s takes a long time.", config@MIP$solver),
-        "Recommended solvers: LPSYMPHONY, RSYMPHONY, or GUROBI",
+        "Recommended solvers: RSYMPHONY, or GUROBI",
         sep = "\n"
       )
 
@@ -450,7 +425,7 @@ validateSolver <- function(config, constraints, purpose = NULL) {
 
 #' Test solver
 #'
-#' @param solver a solver package name. Accepts \code{lpSolve, Rsymphony, lpsymphony, gurobi, Rglpk}.
+#' @param solver a solver package name. Accepts \code{lpSolve, Rsymphony, gurobi, Rglpk}.
 #'
 #' @return empty string \code{""} if solver works. A string containing error messages otherwise.
 #'
@@ -503,7 +478,7 @@ testSolver <- function(solver) {
 #' @export
 detectBestSolver <- function() {
   solver_list <- c(
-    "gurobi", "lpsymphony", "Rsymphony", "lpSolve"
+    "gurobi", "Rsymphony", "lpSolve"
   )
   for (solver in solver_list) {
     is_solver_available <- suppressWarnings(requireNamespace(solver, quietly = TRUE))

--- a/R/static_class.R
+++ b/R/static_class.R
@@ -61,8 +61,8 @@ setClass("config_Static",
       msg <- sprintf("config@item_selection: unexpected $info_type '%s' (accepts FISHER)", toupper(object@item_selection$info_type))
       err <- c(err, msg)
     }
-    if (!toupper(object@MIP$solver) %in% c("LPSYMPHONY", "RSYMPHONY", "GUROBI", "LPSOLVE", "RGLPK")) {
-      msg <- sprintf("config@MIP: unexpected $solver (accepts lpsymphony, Rsymphony, gurobi, lpSolve, or Rglpk)", object@MIP$solver)
+    if (!toupper(object@MIP$solver) %in% c("RSYMPHONY", "GUROBI", "LPSOLVE", "RGLPK")) {
+      msg <- sprintf("config@MIP: unexpected $solver (accepts Rsymphony, gurobi, lpSolve, or Rglpk)", object@MIP$solver)
       err <- c(err, msg)
     }
 
@@ -90,11 +90,11 @@ setClass("config_Static",
 #'
 #' @param MIP a named list containing solver options.
 #' \itemize{
-#'   \item{\code{solver}} the type of solver. Accepts \code{lpsymphony, Rsymphony, gurobi, lpSolve, Rglpk}. (default = \code{LPSOLVE})
+#'   \item{\code{solver}} the type of solver. Accepts \code{Rsymphony, gurobi, lpSolve, Rglpk}. (default = \code{LPSOLVE})
 #'   \item{\code{verbosity}} verbosity level of the solver. (default = \code{-2})
-#'   \item{\code{time_limit}} time limit in seconds. Used in solvers \code{lpsymphony, Rsymphony, gurobi, Rglpk}. (default = \code{60})
+#'   \item{\code{time_limit}} time limit in seconds. Used in solvers \code{Rsymphony, gurobi, Rglpk}. (default = \code{60})
 #'   \item{\code{gap_limit}} search termination criterion. Gap limit in relative scale passed onto the solver. Used in solver \code{gurobi}. (default = \code{.05})
-#'   \item{\code{gap_limit_abs}} search termination criterion. Gap limit in absolute scale passed onto the solver. Used in solvers \code{lpsymphony, Rsymphony}. (default = \code{0.05})
+#'   \item{\code{gap_limit_abs}} search termination criterion. Gap limit in absolute scale passed onto the solver. Used in solvers \code{Rsymphony}. (default = \code{0.05})
 #'   \item{\code{obj_tol}} search termination criterion. The lower bound to use on the minimax deviation variable. Used when \code{item_selection$method} is \code{TIF} or \code{TCC}. (default = \code{0.05})
 #'   \item{\code{retry}} number of times to retry running the solver if the solver returns no solution. Some solvers incorrectly return no solution even when a solution exists. This is the number of attempts to verify that the problem is indeed infeasible in such cases. Set to \code{0} to not retry. (default = \code{5})
 #' }

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,9 +1,9 @@
-# TestDesign 1.3.4
+# TestDesign 1.4.0
 
 ## Test environments
 
 * Local:
-* * Windows 11 (R 4.2.1)
+* * Windows 11 (R 4.2.2)
 * GitHub Actions:
 * * macOS 12 Monterey (R-release)
 * * macOS 11 Big Sur (R-release)
@@ -27,7 +27,7 @@ Information on obtaining 'gurobi' is described in `DESCRIPTION`.
 
 ## Downstream dependencies
 
-The previous version 'TestDesign' 1.3.3 has 1 downstream dependency: 'maat' 1.1.0
+The previous version 'TestDesign' 1.3.4 has 1 downstream dependency: 'maat' 1.1.0
 
 Downstream dependency was checked using 'revdepcheck' available from https://github.com/r-lib/revdepcheck
 

--- a/inst/shiny/global.r
+++ b/inst/shiny/global.r
@@ -5,7 +5,7 @@ suppressPackageStartupMessages(library(shinyjs, quietly = TRUE, warn.conflicts =
 library(DT, quietly = TRUE, warn.conflicts = FALSE)
 library(TestDesign, quietly = TRUE)
 
-solvers <- c("lpSolve", "Rsymphony", "lpsymphony", "gurobi", "Rglpk")
+solvers <- c("lpSolve", "Rsymphony", "gurobi", "Rglpk")
 accepted_files <- c("text/csv", "text/comma-separated-values,text/plain", ".csv")
 css_y <- "overflow-y:scroll; max-height: 65vh"
 

--- a/inst/shiny/server.r
+++ b/inst/shiny/server.r
@@ -110,8 +110,8 @@ server <- function(input, output, session) {
           "shiny_constraints_data",
           "Constraints (raw data.frame)")
 
-        if (isolate(v$constraints@set_based & !input$solvertype %in% c("lpsymphony", "Rsymphony", "gurobi"))) {
-          v <- updateLogs(v, "Warning: set-based assembly requires 'lpsymphony', 'Rsymphony' or 'gurobi'.")
+        if (isolate(v$constraints@set_based & !input$solvertype %in% c("Rsymphony", "gurobi"))) {
+          v <- updateLogs(v, "Warning: set-based assembly requires 'Rsymphony' or 'gurobi'.")
         }
 
       } else {

--- a/man/Split-methods.Rd
+++ b/man/Split-methods.Rd
@@ -49,7 +49,7 @@ When constructing parallel pools, each pool is constructed so that it contains a
 }
 \examples{
 \dontrun{
-config <- createStaticTestConfig(MIP = list(solver = "LPSYMPHONY"))
+config <- createStaticTestConfig(MIP = list(solver = "RSYMPHONY"))
 constraints <- constraints_science[1:10]
 
 solution <- Split(config, constraints, n_partition = 4, partition_type = "test"))

--- a/man/createShadowTestConfig.Rd
+++ b/man/createShadowTestConfig.Rd
@@ -37,11 +37,11 @@ createShadowTestConfig(
 
 \item{MIP}{a named list containing solver options.
 \itemize{
-  \item{\code{solver}} the type of solver. Accepts \code{lpsymphony, Rsymphony, gurobi, lpSolve, Rglpk}. (default = \code{LPSOLVE})
+  \item{\code{solver}} the type of solver. Accepts \code{Rsymphony, gurobi, lpSolve, Rglpk}. (default = \code{LPSOLVE})
   \item{\code{verbosity}} verbosity level of the solver. (default = \code{-2})
-  \item{\code{time_limit}} time limit in seconds. Used in solvers \code{lpsymphony, Rsymphony, gurobi, Rglpk}. (default = \code{60})
+  \item{\code{time_limit}} time limit in seconds. Used in solvers \code{Rsymphony, gurobi, Rglpk}. (default = \code{60})
   \item{\code{gap_limit}} search termination criterion. Gap limit in relative scale passed onto the solver. Used in solver \code{gurobi}. (default = \code{.05})
-  \item{\code{gap_limit_abs}} search termination criterion. Gap limit in absolute scale passed onto the solver. Used in solvers \code{lpsymphony, Rsymphony}. (default = \code{0.05})
+  \item{\code{gap_limit_abs}} search termination criterion. Gap limit in absolute scale passed onto the solver. Used in solvers \code{Rsymphony}. (default = \code{0.05})
   \item{\code{obj_tol}} search termination criterion. The lower bound to use on the minimax deviation variable. Used when \code{item_selection$method} is \code{GFI}, and ignored otherwise. (default = \code{0.05})
   \item{\code{retry}} number of times to retry running the solver if the solver returns no solution. Some solvers incorrectly return no solution even when a solution exists. This is the number of attempts to verify that the problem is indeed infeasible in such cases. Set to \code{0} to not retry. (default = \code{5})
 }}

--- a/man/createStaticTestConfig.Rd
+++ b/man/createStaticTestConfig.Rd
@@ -20,11 +20,11 @@ createStaticTestConfig(item_selection = NULL, MIP = NULL)
 
 \item{MIP}{a named list containing solver options.
 \itemize{
-  \item{\code{solver}} the type of solver. Accepts \code{lpsymphony, Rsymphony, gurobi, lpSolve, Rglpk}. (default = \code{LPSOLVE})
+  \item{\code{solver}} the type of solver. Accepts \code{Rsymphony, gurobi, lpSolve, Rglpk}. (default = \code{LPSOLVE})
   \item{\code{verbosity}} verbosity level of the solver. (default = \code{-2})
-  \item{\code{time_limit}} time limit in seconds. Used in solvers \code{lpsymphony, Rsymphony, gurobi, Rglpk}. (default = \code{60})
+  \item{\code{time_limit}} time limit in seconds. Used in solvers \code{Rsymphony, gurobi, Rglpk}. (default = \code{60})
   \item{\code{gap_limit}} search termination criterion. Gap limit in relative scale passed onto the solver. Used in solver \code{gurobi}. (default = \code{.05})
-  \item{\code{gap_limit_abs}} search termination criterion. Gap limit in absolute scale passed onto the solver. Used in solvers \code{lpsymphony, Rsymphony}. (default = \code{0.05})
+  \item{\code{gap_limit_abs}} search termination criterion. Gap limit in absolute scale passed onto the solver. Used in solvers \code{Rsymphony}. (default = \code{0.05})
   \item{\code{obj_tol}} search termination criterion. The lower bound to use on the minimax deviation variable. Used when \code{item_selection$method} is \code{TIF} or \code{TCC}. (default = \code{0.05})
   \item{\code{retry}} number of times to retry running the solver if the solver returns no solution. Some solvers incorrectly return no solution even when a solution exists. This is the number of attempts to verify that the problem is indeed infeasible in such cases. Set to \code{0} to not retry. (default = \code{5})
 }}

--- a/man/testSolver.Rd
+++ b/man/testSolver.Rd
@@ -8,7 +8,7 @@
 testSolver(solver)
 }
 \arguments{
-\item{solver}{a solver package name. Accepts \code{lpSolve, Rsymphony, lpsymphony, gurobi, Rglpk}.}
+\item{solver}{a solver package name. Accepts \code{lpSolve, Rsymphony, gurobi, Rglpk}.}
 }
 \value{
 empty string \code{""} if solver works. A string containing error messages otherwise.

--- a/tests/testthat/test_excluding.R
+++ b/tests/testthat/test_excluding.R
@@ -51,10 +51,10 @@ resp <- simResp(itempool_reading, true_theta)
 test_that("excluding stimuli works", {
 
   skip_on_cran() # lpsymphony causes ASAN heap-buffer-overflow
-  skip_if_not_installed("lpsymphony")
+  skip_if_not_installed("Rsymphony")
 
   cfg <- createShadowTestConfig(
-    MIP = list(solver = "lpsymphony")
+    MIP = list(solver = "Rsymphony")
   )
 
   set.seed(1)
@@ -116,4 +116,3 @@ test_that("excluding stimuli works", {
   expect_equal(o, FALSE)
 
 })
-

--- a/vignettes/rsymphony.Rmd
+++ b/vignettes/rsymphony.Rmd
@@ -24,8 +24,6 @@ ERROR: configuration failed for package ‘Rsymphony’
 
 This document describes a potential fix to this problem. An admin account is required.
 
-Alternatively, [lpsymphony](https://www.bioconductor.org/packages/release/bioc/html/lpsymphony.html) from Bioconductor repository is supported by TestDesign 1.2.0.
-
 <br/>
 <br/>
 


### PR DESCRIPTION
## Description

- Removed support for the `lpsymphony` solver because of installation issues in some systems. Users may use the `Rsymphony` solver as an alternative.