### PR TITLE
fix combining `constraints` objects

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: TestDesign
 Type: Package
 Title: Optimal Test Design Approach to Fixed and Adaptive Test Construction
-Version: 1.5.1
-Date: 2023-1-26
+Version: 1.5.1.9000
+Date: 2024-1-6
 Authors@R: c(
     person("Seung W.", "Choi",
         email = "schoi@austin.utexas.edu",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,6 @@ Package: TestDesign
 Type: Package
 Title: Optimal Test Design Approach to Fixed and Adaptive Test Construction
 Version: 1.5.1.9000
-Date: 2024-1-6
 Authors@R: c(
     person("Seung W.", "Choi",
         email = "schoi@austin.utexas.edu",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# TestDesign 1.5.1.9000
+
+## Bug fixes
+
+* Fixed where `c()` and `combineConstraints()` were incorrectly combining constraints.
+
 # TestDesign 1.5.1
 
 ## Updates

--- a/R/constraints_operators.R
+++ b/R/constraints_operators.R
@@ -74,8 +74,10 @@ combineConstraintsData <- function(raw1, raw2) {
 
   raw       <- rbind(raw1, raw2)
 
-  idx       <- which(!duplicated(raw$CONSTRAINT))
+  idx       <- which(!duplicated(raw$CONSTRAINT_ID))
   raw       <- raw[idx, ]
+
+  raw$CONSTRAINT <- NULL # because this will be recreated in loadConstraints()
 
   return(raw)
 

--- a/R/eligibility_functions.R
+++ b/R/eligibility_functions.R
@@ -161,8 +161,8 @@ incrementN <- function(o, segments_to_apply, segment_prob, constants) {
 #' @noRd
 incrementPhi <- function(o, segments_to_apply, segment_prob, theta_is_feasible) {
 
-  # for soft costraint exposure control, incrementPhi() is not called for the purpose of code optimization
-  # techinally, incrementPhi() should be always called because test is always feasible when using soft costraint exposure control
+  # for soft constraint exposure control, incrementPhi() is not called for the purpose of code optimization
+  # technically, incrementPhi() should be always called because test is always feasible when using soft constraint exposure control
   # but always incrementing f_jk gives f_jk == n_jk, which is only used to compute n_jk / f_jk = 1
   # hence, skip incrementing and just use 1
   # see updateEligibilityRates()

--- a/R/eligibility_functions.R
+++ b/R/eligibility_functions.R
@@ -145,17 +145,6 @@ applyFading <- function(o, segments_to_apply, constants) {
 }
 
 #' @noRd
-getEligibleFlagInSegment <- function(eligible_flag, segment, constants) {
-  o <- list()
-  o$i <- eligible_flag$i[segment, ]
-  if (!constants$set_based) {
-    return(o)
-  }
-  o$s <- eligible_flag$s[segment, ]
-  return(o)
-}
-
-#' @noRd
 incrementN <- function(o, segments_to_apply, segment_prob, constants) {
 
   o$n_jk[segments_to_apply] <-

--- a/README.Rmd
+++ b/README.Rmd
@@ -2,12 +2,10 @@
 output: github_document
 ---
 
-# TestDesign <img src="man/figures/testdesign_logo.png" align="right" width="192px" height="100%"/>
-
-<!-- badges: start -->
 [![R build status](https://github.com/choi-phd/TestDesign/actions/workflows/r.yml/badge.svg)](https://github.com/choi-phd/TestDesign/actions)
 [![Number of downloads](https://cranlogs.r-pkg.org/badges/grand-total/TestDesign?color=lightgrey)](https://cran.r-project.org/package=TestDesign)
-<!-- badges: end -->
+
+# TestDesign <img src="man/figures/testdesign_logo.png" align="right" width="192px" height="100%"/>
 
 Optimal **Test Design** Approach to Fixed and Adaptive Test Construction
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,10 @@
 
-# TestDesign <img src="man/figures/testdesign_logo.png" align="right" width="192px" height="100%"/>
-
-<!-- badges: start -->
-
 [![R build
 status](https://github.com/choi-phd/TestDesign/actions/workflows/r.yml/badge.svg)](https://github.com/choi-phd/TestDesign/actions)
 [![Number of
 downloads](https://cranlogs.r-pkg.org/badges/grand-total/TestDesign?color=lightgrey)](https://cran.r-project.org/package=TestDesign)
-<!-- badges: end -->
+
+# TestDesign <img src="man/figures/testdesign_logo.png" align="right" width="192px" height="100%"/>
 
 Optimal **Test Design** Approach to Fixed and Adaptive Test Construction
 

--- a/tests/testthat/test_combine_constraints.r
+++ b/tests/testthat/test_combine_constraints.r
@@ -1,0 +1,41 @@
+test_that("combining constraints works", {
+
+  # usual working case
+  expect_warning(
+    o <- c(
+      constraints_science[c(1, 2)],
+      constraints_science[c(1, 10)]
+    ),
+    "duplicate constraint IDs were removed"
+  )
+
+  expect_equal(length(o@list_constraints), 3)
+  expect_equal(o@list_constraints[[1]]@constraint_id, "C1")
+  expect_equal(o@list_constraints[[2]]@constraint_id, "C2")
+  expect_equal(o@list_constraints[[3]]@constraint_id, "C10")
+
+  # edge working case: complete overlap
+  expect_warning(
+    o <- c(
+      constraints_science[c(1, 3, 5)],
+      constraints_science[c(1, 3, 5)]
+    ),
+    "duplicate constraint IDs were removed"
+  )
+
+  expect_equal(length(o@list_constraints), 3)
+  expect_equal(o@list_constraints[[1]]@constraint_id, "C1")
+  expect_equal(o@list_constraints[[2]]@constraint_id, "C3")
+  expect_equal(o@list_constraints[[3]]@constraint_id, "C5")
+
+  # usual non-working case: different constraints source
+
+  expect_error(
+    o <- c(
+      constraints_science[c(1, 2)],
+      constraints_reading[1:3]
+    ),
+    "@pool does not match"
+  )
+
+})


### PR DESCRIPTION
## Description

- Fixed where combining `constraints` objects was not resulting in combined constraints: #160
- Added codetests for the above.
- Combining `constraints` objects no longer complains about the 'CONSTRAINT' column being ignored.
- Removed a duplicate definition for `getEligibleFlagInSegment()`.
- Removed `Date` field from `DESCRIPTION`: CRAN generates this on their own, and this is not needed our side. See https://github.com/r-lib/devtools/issues/1327