### PR TITLE
fix where `Split()` returns set indices even when the pool is all discrete items

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 
 * Fixed where `c()` and `combineConstraints()` were incorrectly combining constraints.
 * Fixed where when examinee-wise priors were supplied for final theta estimation with EAP, the first examinee's prior was being used for all examinees.
+* Fixed where `Split()` was erroneously returning set indices even when the input item pool was entirely comprised of discrete items.
 
 # TestDesign 1.5.1
 

--- a/R/partitioning_functions.r
+++ b/R/partitioning_functions.r
@@ -46,16 +46,34 @@ getDecisionVariablesOfItemForMultipool <- function(item_idx, nv_per_bin, n_bins)
 
 #' @noRd
 splitSolutionToBins <- function(solution, n_bins, ni_per_bin, nv_per_bin) {
+
   o <- list()
+
   for (b in 1:n_bins) {
-    i <- (b - 1) * nv_per_bin + 1:ni_per_bin
-    s <- (b - 1) * nv_per_bin + (ni_per_bin + 1):nv_per_bin
     o[[b]] <- list()
-    o[[b]]$i <- which(solution[i] == 1)
-    o[[b]]$s <- which(solution[s] == 1)
   }
   names(o) <- 1:n_bins
+
+  # if ni_per_bin == nv_per_bin, then it is discrete (not set-based)
+
+  for (b in 1:n_bins) {
+    i <- (b - 1) * nv_per_bin + 1:ni_per_bin
+    o[[b]]$i <- which(solution[i] == 1)
+  }
+
+  if (ni_per_bin == nv_per_bin) {
+    return(o)
+  }
+
+  # if ni_per_bin < nv_per_bin, then it is set-based
+
+  for (b in 1:n_bins) {
+    s <- (b - 1) * nv_per_bin + (ni_per_bin + 1):nv_per_bin
+    o[[b]]$s <- which(solution[s] == 1)
+  }
+
   return(o)
+
 }
 
 #' @noRd

--- a/tests/testthat/test_partitioning_methods.r
+++ b/tests/testthat/test_partitioning_methods.r
@@ -26,6 +26,7 @@ test_that("partitioning methods work", {
   for (partition in o@output) {
     subpool <- constraints@pool[partition$i]
     expect_equal(subpool@ni, constraints@test_length)
+    expect_true(length(partition$s) == 0)
   }
 
   n_partition <- 4
@@ -33,6 +34,7 @@ test_that("partitioning methods work", {
   for (partition in o@output) {
     subpool <- constraints@pool[partition$i]
     expect_equal(subpool@ni, constraints@pool@ni / n_partition)
+    expect_true(length(partition$s) == 0)
   }
 
   n_partition <- 3
@@ -41,6 +43,7 @@ test_that("partitioning methods work", {
     subpool <- constraints@pool[partition$i]
     expect_gte(subpool@ni, 60)
     expect_lte(subpool@ni, 70)
+    expect_true(length(partition$s) == 0)
   }
 
   # set-based assembly
@@ -61,6 +64,7 @@ test_that("partitioning methods work", {
   for (partition in o@output) {
     subpool <- constraints@pool[partition$i]
     expect_equal(subpool@ni, constraints@test_length)
+    expect_true(length(partition$s) > 0)
   }
 
   n_partition <- 2
@@ -69,6 +73,7 @@ test_that("partitioning methods work", {
     subpool <- constraints@pool[partition$i]
     expect_gte(subpool@ni, 140)
     expect_lte(subpool@ni, 160)
+    expect_true(length(partition$s) > 0)
   }
 
 })

--- a/tests/testthat/test_partitioning_methods.r
+++ b/tests/testthat/test_partitioning_methods.r
@@ -6,12 +6,20 @@ test_that("partitioning methods work", {
   solver <- detectBestSolver()
   skip_if(solver == "lpSolve")
 
+  # make a small pool, because existing pools are too big for codetests
+  itempool    <- loadItemPool(itempool_science_data[1:200, ])
+  itemattrib  <- loadItemAttrib(itemattrib_science_data[1:200, ], itempool)
+  constraints <- loadConstraints(constraints_science_data[1:10, ], itempool, itemattrib)
+
   # discrete assembly
 
   set.seed(1)
-
-  config <- createStaticTestConfig(MIP = list(solver = solver, time_limit = 600, obj_tol = 0.25))
-  constraints <- constraints_science[1:10]
+  config <- createStaticTestConfig(
+    MIP = list(
+      solver = solver, time_limit = 600, obj_tol = 0.25,
+      verbosity = 1
+    )
+  )
 
   n_partition <- 4
   o <- Split(config, constraints, n_partition = n_partition, partition_type = "test")
@@ -28,11 +36,11 @@ test_that("partitioning methods work", {
   }
 
   n_partition <- 3
-  o <- Split(config, constraints, n_partition = n_partition, partition_type = "pool", partition_size_range = c(320, 340))
+  o <- Split(config, constraints, n_partition = n_partition, partition_type = "pool", partition_size_range = c(60, 70))
   for (partition in o@output) {
     subpool <- constraints@pool[partition$i]
-    expect_gte(subpool@ni, 320)
-    expect_lte(subpool@ni, 340)
+    expect_gte(subpool@ni, 60)
+    expect_lte(subpool@ni, 70)
   }
 
   # set-based assembly
@@ -40,7 +48,10 @@ test_that("partitioning methods work", {
   set.seed(1)
 
   config <- createStaticTestConfig(
-    MIP = list(solver = solver, time_limit = 600, obj_tol = 0.25),
+    MIP = list(
+      solver = solver, time_limit = 600, obj_tol = 0.25,
+      verbosity = 1
+    ),
     item_selection = list(target_location = c(-2.5, -1.5, -0.5, 0.5, 1.5, 2.5))
   )
   constraints <- constraints_reading[1:5]


### PR DESCRIPTION
## Description

- Fixed #162
- This was a postprocessing error where the raw solver solution is converted to item/set indices.
- Added codetests for the above.