### PR TITLE
fix where final theta estimation with EAP incorrectly uses the first examinee's final theta priors for all examinees

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 * Fixed where `c()` and `combineConstraints()` were incorrectly combining constraints.
+* Fixed where when examinee-wise priors were supplied for final theta estimation with EAP, the first examinee's prior was being used for all examinees.
 
 # TestDesign 1.5.1
 

--- a/R/bayes_functions.R
+++ b/R/bayes_functions.R
@@ -54,7 +54,7 @@ parsePriorParameters <- function(config_theta, constants, prior_density_override
 }
 
 #' @noRd
-getPosteriorConstants <- function(config, constants) {
+getBayesianConstants <- function(config, constants) {
 
   o <- list()
 
@@ -209,14 +209,14 @@ logitHyperPars <- function(mean, sd) {
 }
 
 #' @noRd
-generateItemParameterSample <- function(config, item_pool, posterior_constants) {
+generateItemParameterSample <- function(config, item_pool, bayesian_constants) {
 
   o <- NULL
 
   interim_method <- toupper(config@interim_theta$method)
   final_method   <- toupper(config@final_theta$method)
   if (any(c(interim_method, final_method) %in% c("FB"))) {
-    o <- iparPosteriorSample(item_pool, posterior_constants$n_sample)
+    o <- iparPosteriorSample(item_pool, bayesian_constants$n_sample)
   }
 
   return(o)
@@ -263,11 +263,11 @@ generateDensityFromPriorPar <- function(config_theta, theta_q) {
 }
 
 #' @noRd
-generateSampleFromPriorPar <- function(config_theta, j, posterior_constants) {
+generateSampleFromPriorPar <- function(config_theta, j, bayesian_constants) {
 
   if (config_theta$prior_dist == "NORMAL") {
     prior_sample <- rnorm(
-      posterior_constants$n_sample,
+      bayesian_constants$n_sample,
       mean = config_theta$prior_par[[j]][1],
       sd   = config_theta$prior_par[[j]][2]
     )
@@ -275,7 +275,7 @@ generateSampleFromPriorPar <- function(config_theta, j, posterior_constants) {
   }
   if (config_theta$prior_dist == "UNIFORM") {
     prior_sample <- runif(
-      posterior_constants$n_sample,
+      bayesian_constants$n_sample,
       min = config_theta$prior_par[[j]][1],
       max = config_theta$prior_par[[j]][2]
     )
@@ -285,12 +285,12 @@ generateSampleFromPriorPar <- function(config_theta, j, posterior_constants) {
 }
 
 #' @noRd
-applyThin <- function(posterior_sample, posterior_constants) {
+applyThin <- function(posterior_sample, bayesian_constants) {
 
   posterior_sample <- posterior_sample[seq(
-    from = posterior_constants$burn_in + 1,
-    to   = posterior_constants$n_sample,
-    by   = posterior_constants$thin
+    from = bayesian_constants$burn_in + 1,
+    to   = bayesian_constants$n_sample,
+    by   = bayesian_constants$thin
   )]
 
   return(posterior_sample)

--- a/R/bayes_functions.R
+++ b/R/bayes_functions.R
@@ -20,7 +20,10 @@ parsePriorParameters <- function(config_theta, constants, prior_density_override
   config_theta$prior_dist <- toupper(config_theta$prior_dist)
 
   # if prior_par is a vector, expand to an examinee-wise list
-  if (is.vector(config_theta$prior_par)) {
+  if (
+    is.vector(config_theta$prior_par) &
+    !is.list(config_theta$prior_par) # because a list is also a vector
+  ) {
     config_theta$prior_par <- lapply(1:constants$nj, function(x) config_theta$prior_par)
   }
 

--- a/R/bayes_functions.R
+++ b/R/bayes_functions.R
@@ -2,51 +2,51 @@
 NULL
 
 #' @noRd
-parsePriorParameters <- function(o, constants, prior_density_override, prior_par_override) {
+parsePriorParameters <- function(config_theta, constants, prior_density_override, prior_par_override) {
 
   # override config with prior arguments supplied to Shadow()
   if (!is.null(prior_density_override) & !is.null(prior_par_override)) {
     stop("unexpected 'prior' and 'prior_par': only one must be supplied to Shadow()")
   }
   if (!is.null(prior_density_override)) {
-    o$prior_dist <- "RAW"
-    o$prior_par  <- prior_density_override
+    config_theta$prior_dist <- "RAW"
+    config_theta$prior_par  <- prior_density_override
   }
   if (!is.null(prior_par_override)) {
-    o$prior_dist <- "NORMAL"
-    o$prior_par  <- prior_par_override
+    config_theta$prior_dist <- "NORMAL"
+    config_theta$prior_par  <- prior_par_override
   }
 
-  o$prior_dist <- toupper(o$prior_dist)
+  config_theta$prior_dist <- toupper(config_theta$prior_dist)
 
   # if prior_par is a vector, expand to an examinee-wise list
-  if (is.vector(o$prior_par)) {
-    o$prior_par <- lapply(1:constants$nj, function(x) o$prior_par)
+  if (is.vector(config_theta$prior_par)) {
+    config_theta$prior_par <- lapply(1:constants$nj, function(x) config_theta$prior_par)
   }
 
   # if prior_par is a matrix, expand to an examinee-wise list
-  if (is.matrix(o$prior_par)) {
-    o$prior_par <- apply(o$prior_par, 1, function(x) {x}, simplify = FALSE)
+  if (is.matrix(config_theta$prior_par)) {
+    config_theta$prior_par <- apply(config_theta$prior_par, 1, function(x) {x}, simplify = FALSE)
   }
 
   # if prior_par is a list, validate
-  if (is.list(o$prior_par)) {
-    if (length(o$prior_par) != constants$nj) {
+  if (is.list(config_theta$prior_par)) {
+    if (length(config_theta$prior_par) != constants$nj) {
       stop("unexpected 'prior_par': could not be expanded to a length-nj list (must be a length-2 vector, an nj * 2 matrix, or a length-nj list)")
     }
-    n_prior_par <- unlist(lapply(o$prior_par, length))
-    if (o$prior_dist == "NORMAL" & any(n_prior_par != 2)) {
+    n_prior_par <- unlist(lapply(config_theta$prior_par, length))
+    if (config_theta$prior_dist == "NORMAL" & any(n_prior_par != 2)) {
       stop("unexpected 'prior_par': for 'NORMAL' distribution, each list element must be a length-2 vector")
     }
-    if (o$prior_dist == "UNIFORM" & any(n_prior_par != 2)) {
+    if (config_theta$prior_dist == "UNIFORM" & any(n_prior_par != 2)) {
       stop("unexpected 'prior_par': for 'UNIFORM' distribution, each list element must be a length-2 vector")
     }
-    if (o$prior_dist == "RAW" & any(n_prior_par != constants$nq)) {
+    if (config_theta$prior_dist == "RAW" & any(n_prior_par != constants$nq)) {
       stop("unexpected 'prior_par': for 'RAW' distribution, each list element must be a length-nq vector")
     }
   }
 
-  return(o)
+  return(config_theta)
 
 }
 

--- a/R/bayes_functions.R
+++ b/R/bayes_functions.R
@@ -54,7 +54,7 @@ parsePriorParameters <- function(config_theta, constants, prior_density_override
 }
 
 #' @noRd
-getPosteriorConstants <- function(config) {
+getPosteriorConstants <- function(config, constants) {
 
   o <- list()
 
@@ -67,6 +67,12 @@ getPosteriorConstants <- function(config) {
     o$thin        <- config@MCMC$thin
     o$jump_factor <- config@MCMC$jump_factor
   }
+
+  # generate prior densities from config
+  o$final_theta_prior_densities <- generateDensityFromPriorPar(
+    config@final_theta,
+    constants$theta_q
+  )
 
   return(o)
 
@@ -218,9 +224,10 @@ generateItemParameterSample <- function(config, item_pool, posterior_constants) 
 }
 
 #' @noRd
-generateDensityFromPriorPar <- function(config_theta, theta_q, nj) {
+generateDensityFromPriorPar <- function(config_theta, theta_q) {
 
   nq <- nrow(theta_q)
+  nj <- length(config_theta$prior_par) # this is an examinee-wise list
   prior_density <- NULL
 
   if (config_theta$prior_dist == "NORMAL") {

--- a/R/shadow_functions.R
+++ b/R/shadow_functions.R
@@ -87,7 +87,7 @@ setMethod(
     constants             <- getConstants(constraints, config, data, true_theta, simulation_data_cache@max_info)
     config@interim_theta  <- parsePriorParameters(config@interim_theta, constants, prior, prior_par)
     config@final_theta    <- parsePriorParameters(config@final_theta  , constants, prior, prior_par)
-    posterior_constants   <- getPosteriorConstants(config)
+    posterior_constants   <- getPosteriorConstants(config, constants)
     initial_theta         <- parseInitialTheta(config, constants, item_pool, posterior_constants, include_items_for_estimation)
     item_parameter_sample <- generateItemParameterSample(config, item_pool, posterior_constants)
     exclude_index         <- getIndexOfExcludedEntry(exclude, constraints)

--- a/R/shadow_functions.R
+++ b/R/shadow_functions.R
@@ -87,9 +87,9 @@ setMethod(
     constants             <- getConstants(constraints, config, data, true_theta, simulation_data_cache@max_info)
     config@interim_theta  <- parsePriorParameters(config@interim_theta, constants, prior, prior_par)
     config@final_theta    <- parsePriorParameters(config@final_theta  , constants, prior, prior_par)
-    posterior_constants   <- getPosteriorConstants(config, constants)
-    initial_theta         <- parseInitialTheta(config, constants, item_pool, posterior_constants, include_items_for_estimation)
-    item_parameter_sample <- generateItemParameterSample(config, item_pool, posterior_constants)
+    bayesian_constants    <- getBayesianConstants(config, constants)
+    initial_theta         <- parseInitialTheta(config, constants, item_pool, bayesian_constants, include_items_for_estimation)
+    item_parameter_sample <- generateItemParameterSample(config, item_pool, bayesian_constants)
     exclude_index         <- getIndexOfExcludedEntry(exclude, constraints)
 
     # Only used if config@item_selection$method = "FIXED"
@@ -161,7 +161,7 @@ setMethod(
         config@interim_theta,
         initial_theta,
         j,
-        posterior_constants
+        bayesian_constants
       )
       o@initial_theta_est <- current_theta
 
@@ -351,7 +351,7 @@ setMethod(
           item_parameter_sample,
           config,
           constants,
-          posterior_constants
+          bayesian_constants
         )
 
         theta_change                   <- o@interim_theta_est[position, ] - current_theta$theta
@@ -384,7 +384,7 @@ setMethod(
         item_parameter_sample,
         config,
         constants,
-        posterior_constants
+        bayesian_constants
       )
 
       # Simulee: record item usage

--- a/R/theta_functions.R
+++ b/R/theta_functions.R
@@ -189,13 +189,7 @@ estimateFinalTheta <- function(
 
   if (toupper(config@final_theta$method == "EAP")) {
 
-    final_prior <- generateDensityFromPriorPar(
-      config@final_theta,
-      constants$theta_q,
-      nj = 1
-    )[1, ]
-
-    o@posterior       <- o@likelihood * final_prior
+    o@posterior       <- o@likelihood * posterior_constants$final_theta_prior_densities[j, ]
     final_EAP <- computeEAPFromPosterior(o@posterior, constants$theta_q)
     final_EAP <- applyShrinkageCorrection(final_EAP, config@final_theta, j)
     o@final_theta_est <- final_EAP$theta
@@ -1046,8 +1040,7 @@ parseInitialTheta <- function(config, constants, item_pool, posterior_constants,
 
   o$posterior <- generateDensityFromPriorPar(
     config@interim_theta,
-    constants$theta_q,
-    constants$nj
+    constants$theta_q
   )
 
   o$theta_q <- constants$theta_q


### PR DESCRIPTION
## Description

- Fixed #163 .