### PR TITLE
fix MacOS cross builds

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,0 +1,1 @@
+PKG_LIBS=$(BLAS_LIBS) $(FLIBS)

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,1 +1,0 @@
-PKG_LIBS=$(BLAS_LIBS)


### PR DESCRIPTION
## Description

- The proper way to link to BLAS is like this (see [WRE section 1.2.1](https://cran.r-project.org/doc/manuals/R-exts.html#Using-Makevars)).
- This fixes the macos cross compilation: https://github.com/r-universe/choi-phd/actions/runs/7576934286/job/20636902845