### PR TITLE
added notes to not remove `j` subscripts in exposure record

### DIFF
--- a/R/exposure_control_functions.R
+++ b/R/exposure_control_functions.R
@@ -110,6 +110,12 @@ initializeSegmentRecord <- function(constants) {
 #' @noRd
 initializeExposureRecord <- function(exposure_control, constants) {
 
+  # the j subscript used here is intentional and should not be removed.
+  # the notation scheme is from van der Linden, W. J., & Veldkamp, B. P. (2007).
+  # for example, a_ijk here is interpreted as:
+  # - the number of examinees until j-th examinee who was in theta segment k and was administered item i.
+  # - see how this interpretation does not imply the variable is a three-dimensional array.
+
   o <- list()
 
   ni <- constants$ni


### PR DESCRIPTION
## Description

- Added a note describing the `j` subscript should not be removed.
- ~~Updated the naming scheme for exposure record lists to not use the `j` subscript. Having the `j` subscript is misleading because the actual stored data is not examinee-wise data.~~
- ~~Added functions to make this change backwards compatible. When an old format input is detected, `Shadow()` will inform the user and update the input to the current version.~~
- ~~Added codetests for this.~~