### PR TITLE
`Split()`: add a new argument `n_maximum_partitions_per_item` 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # TestDesign 1.5.1.9000
 
+## New features
+
+* `Split()` gains a new argument `n_maximum_partitions_per_item` for allowing items to be assigned to multiple partitions.
+
 ## Updates
 
 * Updated `vignette('constraints')`.

--- a/R/partitioning_functions.r
+++ b/R/partitioning_functions.r
@@ -171,6 +171,10 @@ setMethod(
       }
     }
 
+    if (n_maximum_partitions_per_item >= n_partition) {
+      message("the supplied value of 'n_maximum_partitions_per_item' is equal to (or larger than) the supplied value of 'n_partition'. This will result in all assembled partitions to be identical, because that is where information difference is minimized.")
+    }
+
     itempool          <- constraints@pool
     ni                <- constraints@ni
     nv                <- constraints@nv

--- a/man/Split-methods.Rd
+++ b/man/Split-methods.Rd
@@ -12,6 +12,7 @@ Split(
   n_partition,
   partition_type,
   partition_size_range = NULL,
+  n_maximum_partitions_per_item = 1,
   force_solver = FALSE
 )
 
@@ -21,6 +22,7 @@ Split(
   n_partition,
   partition_type,
   partition_size_range = NULL,
+  n_maximum_partitions_per_item = 1,
   force_solver = FALSE
 )
 }
@@ -36,6 +38,12 @@ Split(
 \item{partition_size_range}{(optional) two integer values for the desired range for the size of a partition. Has no effect when \code{partition_type} is \code{test}.
 For discrete item pools, the default partition size is (pool size / number of partitions).
 For set-based item pools, the default partition size is (pool size / number of partitions) +/- smallest set size.}
+
+\item{n_maximum_partitions_per_item}{(optional) the number of times an item can be assigned to a partition.
+Setting this to 1 is equivalent to requiring all partitions to be mutually exclusive.
+A caveat is that when this is equal to \code{n_partition}, the assembled partitions will be identical to each other,
+because \code{\link{Split}} aims to minimize the test information difference between all partitions.
+(default = \code{1})}
 
 \item{force_solver}{if \code{TRUE}, do not check whether the solver is one of recommended solvers for complex problems (set-based assembly, partitioning). (default = \code{FALSE})}
 }

--- a/tests/testthat/test_partitioning_methods.r
+++ b/tests/testthat/test_partitioning_methods.r
@@ -11,7 +11,7 @@ test_that("partitioning methods work", {
   itemattrib  <- loadItemAttrib(itemattrib_science_data[1:200, ], itempool)
   constraints <- loadConstraints(constraints_science_data[1:10, ], itempool, itemattrib)
 
-  # discrete assembly
+  # discrete assembly ----------------------------------------------------------
 
   set.seed(1)
   config <- createStaticTestConfig(
@@ -21,6 +21,7 @@ test_that("partitioning methods work", {
     )
   )
 
+  # multiple tests
   n_partition <- 4
   o <- Split(config, constraints, n_partition = n_partition, partition_type = "test")
   for (partition in o@output) {
@@ -29,6 +30,7 @@ test_that("partitioning methods work", {
     expect_true(length(partition$s) == 0)
   }
 
+  # multiple pools
   n_partition <- 4
   o <- Split(config, constraints, n_partition = n_partition, partition_type = "pool")
   for (partition in o@output) {
@@ -37,6 +39,7 @@ test_that("partitioning methods work", {
     expect_true(length(partition$s) == 0)
   }
 
+  # multiple pools (dynamic size)
   n_partition <- 3
   o <- Split(config, constraints, n_partition = n_partition, partition_type = "pool", partition_size_range = c(60, 70))
   for (partition in o@output) {
@@ -46,7 +49,59 @@ test_that("partitioning methods work", {
     expect_true(length(partition$s) == 0)
   }
 
-  # set-based assembly
+  # allow items to be assigned to multiple tests
+  n_partition <- 3
+  n_maximum_partitions_per_item <- 2
+  o <- Split(
+    config, constraints, n_partition = n_partition, partition_type = "test",
+    n_maximum_partitions_per_item = n_maximum_partitions_per_item
+  )
+  for (partition in o@output) {
+    subpool <- constraints@pool[partition$i]
+    expect_equal(subpool@ni, constraints@test_length)
+    expect_true(length(partition$s) == 0)
+  }
+  all_partitions <- unlist(lapply(o@output, function(x) x$i))
+  expect_true(all(table(all_partitions) <= n_maximum_partitions_per_item))
+
+  # allow items to be assigned to multiple pools
+  n_partition <- 3
+  n_maximum_partitions_per_item <- 2
+  o <- Split(
+    config, constraints, n_partition = n_partition, partition_type = "pool",
+    n_maximum_partitions_per_item = n_maximum_partitions_per_item,
+    partition_size_range = c(60, 70)
+  )
+  for (partition in o@output) {
+    subpool <- constraints@pool[partition$i]
+    expect_gte(subpool@ni, 60)
+    expect_lte(subpool@ni, 70)
+    expect_true(length(partition$s) == 0)
+  }
+  all_partitions <- unlist(lapply(o@output, function(x) x$i))
+  expect_true(all(table(all_partitions) <= n_maximum_partitions_per_item))
+
+  # set-based assembly ---------------------------------------------------------
+
+  # make a small pool, because existing pools are too big for codetests
+  itempool    <- loadItemPool(itempool_reading_data[1:112, ])
+  itemattrib  <- loadItemAttrib(itemattrib_reading_data[1:112, ], itempool)
+  stimattrib  <- loadStAttrib(stimattrib_reading_data[1:12, ], itemattrib)
+  constraints_reading_data_short <- constraints_reading_data[1:5, ]
+  constraints_reading_data_short[1, "LB"] <- 10
+  constraints_reading_data_short[1, "UB"] <- 10
+  constraints_reading_data_short[2, "LB"] <- 2
+  constraints_reading_data_short[2, "UB"] <- 2
+  constraints_reading_data_short[4, "LB"] <- 5
+  constraints_reading_data_short[4, "UB"] <- 5
+  constraints_reading_data_short[5, "LB"] <- 5
+  constraints_reading_data_short[5, "UB"] <- 5
+  constraints <- loadConstraints(
+    constraints_reading_data_short,
+    itempool,
+    itemattrib,
+    stimattrib
+  )
 
   set.seed(1)
 
@@ -57,8 +112,8 @@ test_that("partitioning methods work", {
     ),
     item_selection = list(target_location = c(-2.5, -1.5, -0.5, 0.5, 1.5, 2.5))
   )
-  constraints <- constraints_reading[1:5]
 
+  # multiple tests
   n_partition <- 2
   o <- Split(config, constraints, n_partition = n_partition, partition_type = "test")
   for (partition in o@output) {
@@ -67,13 +122,46 @@ test_that("partitioning methods work", {
     expect_true(length(partition$s) > 0)
   }
 
+  # multiple pools (dynamic size)
   n_partition <- 2
-  o <- Split(config, constraints, n_partition = n_partition, partition_type = "pool", partition_size_range = c(140, 160))
+  o <- Split(config, constraints, n_partition = n_partition, partition_type = "pool", partition_size_range = c(50, 60))
   for (partition in o@output) {
     subpool <- constraints@pool[partition$i]
-    expect_gte(subpool@ni, 140)
-    expect_lte(subpool@ni, 160)
+    expect_gte(subpool@ni, 50)
+    expect_lte(subpool@ni, 60)
     expect_true(length(partition$s) > 0)
   }
+
+  # allow items to be assigned to multiple tests
+  n_partition <- 3
+  n_maximum_partitions_per_item <- 2
+  o <- Split(
+    config, constraints, n_partition = n_partition, partition_type = "test",
+    n_maximum_partitions_per_item = n_maximum_partitions_per_item
+  )
+  for (partition in o@output) {
+    subpool <- constraints@pool[partition$i]
+    expect_equal(subpool@ni, constraints@test_length)
+    expect_true(length(partition$s) > 0)
+  }
+  all_partitions <- unlist(lapply(o@output, function(x) x$s))
+  expect_true(all(table(all_partitions) <= n_maximum_partitions_per_item))
+
+  # allow items to be assigned to multiple pools
+  n_partition <- 3
+  n_maximum_partitions_per_item <- 2
+  o <- Split(
+    config, constraints, n_partition = n_partition, partition_type = "pool",
+    n_maximum_partitions_per_item = n_maximum_partitions_per_item,
+    partition_size_range = c(30, 40)
+  )
+  for (partition in o@output) {
+    subpool <- constraints@pool[partition$i]
+    expect_gte(subpool@ni, 30)
+    expect_lte(subpool@ni, 40)
+    expect_true(length(partition$s) > 0)
+  }
+  all_partitions <- unlist(lapply(o@output, function(x) x$s))
+  expect_true(all(table(all_partitions) <= n_maximum_partitions_per_item))
 
 })


### PR DESCRIPTION
## Description

- Added a feature we have been discussing for a long time; added a new argument `n_maximum_partitions_per_item` to `Split()`. This allows the function to assemble partitions in a way that each item is allowed to be assigned to multiple partitions. The existing case of assembling all partitions to be mutually exclusive is equivalent to `n_maximum_partitions_per_item = 1` (default).
- If the assembly is set-based, each set will be allowed to be assigned to multiple partitions.
- Added codetests for this.
- Simplified codetests for `Split()` to use smaller tasks.