### PR TITLE
fix markup error in `getSolution()` documentation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: TestDesign
 Type: Package
 Title: Optimal Test Design Approach to Fixed and Adaptive Test Construction
-Version: 1.6.0
+Version: 1.6.1
 Authors@R: c(
     person("Seung W.", "Choi",
         email = "schoi@austin.utexas.edu",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# TestDesign 1.5.1.9000
+# TestDesign 1.6.1
 
 ## New features
 

--- a/R/helper_functions.R
+++ b/R/helper_functions.R
@@ -6,7 +6,7 @@ NULL
 #' @param object an \code{\linkS4class{output_Static}} object or an \code{\linkS4class{output_Shadow}} object.
 #' @param examinee (optional) the examinee index to display the solution. Used when the 'object' argument is an \code{\linkS4class{output_Shadow}} object.
 #' @param position (optional) if supplied, display the item attributes of the assembled test at that item position. If not supplied, display the item attributes of the administered items. Used when the 'object' argument is an \code{\linkS4class{output_Shadow}} object.
-#' @param index_only if \code{TRUE}, only print item indices. if \code{FALSE}, print all item attributes. (default = {TRUE})
+#' @param index_only if \code{TRUE}, only print item indices. if \code{FALSE}, print all item attributes. (default = \code{TRUE})
 #'
 #' @return Item attributes of solution items.
 #'

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,4 +1,6 @@
-# TestDesign 1.6.0
+# TestDesign 1.6.1
+
+This is a resubmission. The previous version 1.6.0 had a markup error in getSolution-methods.Rd; the error was fixed in this submission.
 
 ## Test environments
 

--- a/man/getSolution-methods.Rd
+++ b/man/getSolution-methods.Rd
@@ -20,7 +20,7 @@ getSolution(object, examinee = NA, position = NA, index_only = TRUE)
 
 \item{position}{(optional) if supplied, display the item attributes of the assembled test at that item position. If not supplied, display the item attributes of the administered items. Used when the 'object' argument is an \code{\linkS4class{output_Shadow}} object.}
 
-\item{index_only}{if \code{TRUE}, only print item indices. if \code{FALSE}, print all item attributes. (default = {TRUE})}
+\item{index_only}{if \code{TRUE}, only print item indices. if \code{FALSE}, print all item attributes. (default = \code{TRUE})}
 }
 \value{
 Item attributes of solution items.


### PR DESCRIPTION
## Description

- Fixed a markup error in the documentation of `getSolution()`, as informed by CRAN.
- For some reason this was not picked up in local checks (Windows, Mac).