### PR TITLE
fix Shiny app `TestDesign()` to generate examinee-wise plots correctly

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: TestDesign
 Type: Package
 Title: Optimal Test Design Approach to Fixed and Adaptive Test Construction
-Version: 1.6.1
+Version: 1.6.1.9000
 Authors@R: c(
     person("Seung W.", "Choi",
         email = "schoi@austin.utexas.edu",

--- a/inst/shiny/server.r
+++ b/inst/shiny/server.r
@@ -214,7 +214,7 @@ server <- function(input, output, session) {
         if (input$simulee_id != "") {
           v <- updateLogs(v, sprintf("Created plots for simulee %i", v$simulee_id))
 
-          plot(v$fit, v$simulee_id, type = "audit")
+          plot(v$fit, examinee_id = v$simulee_id, type = "audit")
           p <- recordPlot()
           dev.off()
 
@@ -224,7 +224,7 @@ server <- function(input, output, session) {
             sprintf("Audit trail plot for simulee %i", v$simulee_id)
           )
 
-          plot(v$fit, v$simulee_id, type = "shadow", simple = TRUE)
+          plot(v$fit, examinee_id = v$simulee_id, type = "shadow", simple = TRUE)
           p <- recordPlot()
           dev.off()
 


### PR DESCRIPTION
## Description

- Fixed where the Shiny app `TestDesign()` was not generating plots for the specified examinee ID.