### PR TITLE
fix Shiny app `TestDesign()` where using the info range button without data loaded would crash the app

### DIFF
--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -19,8 +19,8 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
 
+      - uses: actions/checkout@v4
       - uses: r-lib/actions/setup-pandoc@v2
 
       - uses: r-lib/actions/setup-r@v2

--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -11,7 +11,6 @@ name: pkgdown
 jobs:
   pkgdown:
     runs-on: ubuntu-latest
-    # Only restrict concurrency for non-PR jobs
     concurrency:
       group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
     env:
@@ -19,14 +18,11 @@ jobs:
     permissions:
       contents: write
     steps:
-
       - uses: actions/checkout@v4
       - uses: r-lib/actions/setup-pandoc@v2
-
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
-
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: |
@@ -34,11 +30,9 @@ jobs:
             local::.
             gurobi=?ignore
           needs: website
-
       - name: Build site
         run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
         shell: Rscript {0}
-
       - name: Deploy to GitHub pages 🚀
         if: github.event_name != 'pull_request'
         uses: JamesIves/github-pages-deploy-action@v4.4.1

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -34,8 +34,8 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v2
 
+      - uses: actions/checkout@v4
       - uses: r-lib/actions/setup-pandoc@v2
 
       - uses: r-lib/actions/setup-r@v2

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -15,9 +15,7 @@ name: R-CMD-check
 jobs:
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}
-
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})
-
     strategy:
       fail-fast: false
       matrix:
@@ -28,22 +26,17 @@ jobs:
           - {os: ubuntu-22.04, r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-22.04, r: 'release'}
           - {os: ubuntu-22.04, r: 'oldrel'}
-
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
-
     steps:
-
       - uses: actions/checkout@v4
       - uses: r-lib/actions/setup-pandoc@v2
-
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
-
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           dependencies: '"hard"' # ignore Suggests and Enhances
@@ -55,7 +48,6 @@ jobs:
             any::testthat
             any::progress
           needs: check
-
       - uses: r-lib/actions/check-r-package@v2
         env:
           _R_CHECK_FORCE_SUGGESTS_: false

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -28,7 +28,6 @@ jobs:
           - {os: ubuntu-22.04, r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-22.04, r: 'release'}
           - {os: ubuntu-22.04, r: 'oldrel'}
-          - {os: ubuntu-22.04, r: '3.6'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Description: Uses the optimal test design approach by Birnbaum (1968, ISBN:97815
 URL: https://choi-phd.github.io/TestDesign/ (documentation)
 BugReports: https://github.com/choi-phd/TestDesign/issues/
 License: GPL (>= 2)
-Depends: R (>= 2.10)
+Depends: R (>= 4.0)
 biocViews:
 Imports: Rcpp (>= 1.0.0), methods, lpSolve, foreach, logitnorm, crayon
 SystemRequirements: C++17

--- a/inst/shiny/server.r
+++ b/inst/shiny/server.r
@@ -171,7 +171,7 @@ server <- function(input, output, session) {
     shinyjs::toggle("objtype",                        condition = input$problemtype == 1)
     shinyjs::toggle("item_selection_target_location", condition = input$problemtype == 1)
     shinyjs::toggle("item_selection_target_value",    condition = input$problemtype == 1)
-    shinyjs::toggle("maxinfo_button",                 condition = input$problemtype == 1)
+    shinyjs::toggle("obtainable_info_range_button",   condition = input$problemtype == 1)
     shinyjs::toggle("exposure_dropdown",              condition = input$problemtype == 2)
     shinyjs::toggle("theta_settings",                 condition = input$problemtype == 2)
     shinyjs::toggle("item_selection_method",          condition = input$problemtype == 2)
@@ -238,7 +238,7 @@ server <- function(input, output, session) {
     }
   })
 
-  observeEvent(input$maxinfo_button, {
+  observeEvent(input$obtainable_info_range_button, {
     if (v$itempool_exists & v$constraints_exists) {
 
       plot(v$constraints)
@@ -256,7 +256,7 @@ server <- function(input, output, session) {
     }
     updateCheckboxGroupButtons(
       session = session,
-      inputId = "maxinfo_button",
+      inputId = "obtainable_info_range_button",
       selected = character(0)
     )
   })

--- a/inst/shiny/server.r
+++ b/inst/shiny/server.r
@@ -239,6 +239,10 @@ server <- function(input, output, session) {
   })
 
   observeEvent(input$obtainable_info_range_button, {
+
+    if (!(v$itempool_exists & v$constraints_exists)) {
+      v <- updateLogs(v, "Cannot generate info range plot; item pool and constraints must be loaded.")
+    }
     if (v$itempool_exists & v$constraints_exists) {
 
       plot(v$constraints)

--- a/inst/shiny/server.r
+++ b/inst/shiny/server.r
@@ -2,7 +2,7 @@ server <- function(input, output, session) {
   v <- reactiveValues(
     itempool_exists = FALSE,
     itemse_exists = FALSE,
-    const_exists = FALSE,
+    constraints_exists = FALSE,
     itemtext_exists = FALSE,
     stimattrib_exists = FALSE,
     problemtype = 0,

--- a/inst/shiny/styles.css
+++ b/inst/shiny/styles.css
@@ -4,7 +4,8 @@
 
 h2 {
   font-size: 170%;
-} /* bold title */
+  font-weight: bold;
+}
 
 h3 {
   font-size: 12px;

--- a/inst/shiny/styles.css
+++ b/inst/shiny/styles.css
@@ -1,5 +1,5 @@
 :focus {
-    outline: -webkit-focus-ring-color auto 0;
+  outline: -webkit-focus-ring-color auto 0;
 }
 
 h2 {
@@ -7,168 +7,168 @@ h2 {
 } /* bold title */
 
 h3 {
-    font-size: 12px;
-    font-weight: bold;
-    text-transform: none;
-    color: #555555;
+  font-size: 12px;
+  font-weight: bold;
+  text-transform: none;
+  color: #555555;
 }
 
 .form-control {
-    font-size: 12px;
-    text-transform: none;
-    color: #555555;
-    -moz-box-shadow: inset 0 0 0 rgba(0,0,0,0.075);
-    -webkit-box-shadow: inset 0 0 0 rgba(0,0,0,0.075);
-    box-shadow: inset 0 0 0 rgba(0,0,0,0.075);
+  font-size: 12px;
+  text-transform: none;
+  color: #555555;
+  -moz-box-shadow: inset 0 0 0 rgba(0,0,0,0.075);
+  -webkit-box-shadow: inset 0 0 0 rgba(0,0,0,0.075);
+  box-shadow: inset 0 0 0 rgba(0,0,0,0.075);
 }
 
 i {
-    display: inline-block;
-    margin-right: 0.2em;
+  display: inline-block;
+  margin-right: 0.2em;
 }
 
 label, .form-group, .progress {
-    margin-bottom: 0;
+  margin-bottom: 0;
 }
 
 select {
-    min-width: 100%;
-    max-width: 100%;
+  min-width: 100%;
+  max-width: 100%;
 }
 
 .span4 {
-    min-width: 100%;
-    max-width: 100%;
+  min-width: 100%;
+  max-width: 100%;
 }
 
 .well {
-    min-width: 100%;
-    max-width: 100%;
+  min-width: 100%;
+  max-width: 100%;
 }
 
 #text_output {
-    background-color: rgb(64,64,64);
-    color: cyan;
-    overflow-y:auto;
-    height: 64px;
-    display: flex;
-    flex-direction: column-reverse;
+  background-color: rgb(64,64,64);
+  color: cyan;
+  overflow-y:auto;
+  height: 64px;
+  display: flex;
+  flex-direction: column-reverse;
 }
 
 .shiny-notification {
-    font-size: 20px;
-    background-color: #404040;
-    color: #fff;
+  font-size: 20px;
+  background-color: #404040;
+  color: #fff;
 }
 
 #shiny-notification-panel {
-    width: 500px;
+  width: 500px;
 }
 
 .progress {
-    margin-top: -10px;
-    margin-bottom: 15px;
+  margin-top: -10px;
+  margin-bottom: 15px;
 }
 
 .progress.shiny-file-input-progress {
-    margin-top: 0;
-    margin-bottom: 0;
+  margin-top: 0;
+  margin-bottom: 0;
 }
 
 .progress-number {
-    font-size: 0;
+  font-size: 0;
 }
 
 .progress-bar {
-    line-height: 1.5em;
-    -moz-box-shadow: inset 0 0 0 rgba(0,0,0,0.15);
-    -webkit-box-shadow: inset 0 0 0 rgba(0,0,0,0.15);
-    box-shadow: inset 0 0 0 rgba(0,0,0,0.15);
+  line-height: 1.5em;
+  -moz-box-shadow: inset 0 0 0 rgba(0,0,0,0.15);
+  -webkit-box-shadow: inset 0 0 0 rgba(0,0,0,0.15);
+  box-shadow: inset 0 0 0 rgba(0,0,0,0.15);
 }
 
 .btn {
-    width: 100%;
-    border-width: 1px;
-    padding: 7px 12px;
-    text-transform: none;
-    text-align: left;
+  width: 100%;
+  border-width: 1px;
+  padding: 7px 12px;
+  text-transform: none;
+  text-align: left;
 }
 
 .btn:focus {
-    outline: none !important;
-    border-width: 1px;
-    margin-top: 0;
+  outline: none !important;
+  border-width: 1px;
+  margin-top: 0;
 }
 
 .btn:hover {
-    border-width: 1px;
-    margin-top: 0;
+  border-width: 1px;
+  margin-top: 0;
 }
 
 .well {
-    -moz-box-shadow: inset 0 0 0 rgba(0,0,0,0.05);
-    -webkit-box-shadow: inset 0 0 0 rgba(0,0,0,0.05);
-    box-shadow: inset 0 0 0 rgba(0,0,0,0.05);
+  -moz-box-shadow: inset 0 0 0 rgba(0,0,0,0.05);
+  -webkit-box-shadow: inset 0 0 0 rgba(0,0,0,0.05);
+  box-shadow: inset 0 0 0 rgba(0,0,0,0.05);
 }
 
 .form-control {
-    -moz-box-shadow: inset 0 0 0 rgba(0,0,0,0.075);
-    -webkit-box-shadow: inset 0 0 0 rgba(0,0,0,0.075);
-    box-shadow: inset 0 0 0 rgba(0,0,0,0.075);
+  -moz-box-shadow: inset 0 0 0 rgba(0,0,0,0.075);
+  -webkit-box-shadow: inset 0 0 0 rgba(0,0,0,0.075);
+  box-shadow: inset 0 0 0 rgba(0,0,0,0.075);
 }
 
 .form-control[readonly] {
-    background-color: transparent;
-    height: auto;
+  background-color: transparent;
+  height: auto;
 }
 
 .form-control[disabled] {
-    background-color: #ffffff;
-    opacity: 0.2;
+  background-color: #ffffff;
+  opacity: 0.2;
 }
 
 .progress {
-    -moz-box-shadow: inset 0 2px 0 rgba(0,0,0,0.1);
-    -webkit-box-shadow: inset 0 2px 0 rgba(0,0,0,0.1);
-    box-shadow: inset 0 0 0 rgba(0,0,0,0.1);
+  -moz-box-shadow: inset 0 2px 0 rgba(0,0,0,0.1);
+  -webkit-box-shadow: inset 0 2px 0 rgba(0,0,0,0.1);
+  box-shadow: inset 0 0 0 rgba(0,0,0,0.1);
 }
 
 .progress-striped .progress-bar, .progress-bar-striped {
-    background-image: -webkit-linear-gradient(45deg, transparent, transparent);
-    background-image: -o-linear-gradient(45deg, transparent, transparent);
-    background-image: linear-gradient(45deg, transparent, transparent);
-    -webkit-background-size: 40px 40px;
-    background-size: 40px 40px;
+  background-image: -webkit-linear-gradient(45deg, transparent, transparent);
+  background-image: -o-linear-gradient(45deg, transparent, transparent);
+  background-image: linear-gradient(45deg, transparent, transparent);
+  -webkit-background-size: 40px 40px;
+  background-size: 40px 40px;
 }
 
 button {
-    overflow: hidden;
+  overflow: hidden;
 }
 
 .btn.disabled {
-    opacity: 0.2;
+  opacity: 0.2;
 }
 
 html {
-    overflow:scroll;
-    overflow-x:hidden;
+  overflow:scroll;
+  overflow-x:hidden;
 }
 
 ::-webkit-scrollbar {
-    width:0;
-    background:transparent;
+  width:0;
+  background:transparent;
 }
 
 label {
-    font-weight: bold;
-    text-transform: none;
-    font-size: 12px;
+  font-weight: bold;
+  text-transform: none;
+  font-size: 12px;
 }
 
 .dropdown-menu {
-    padding: 20px 0 40px 0px;
-    border-width: 0 1px 1px 1px;
-    border: 1px solid #444;
+  padding: 20px 0 40px 0px;
+  border-width: 0 1px 1px 1px;
+  border: 1px solid #444;
 }
 
 .nav-tabs>li>a {

--- a/inst/shiny/ui.r
+++ b/inst/shiny/ui.r
@@ -57,7 +57,7 @@ ui <- fluidPage(
       h3(""),
 
       checkboxGroupButtons(
-        inputId = "maxinfo_button", justified = TRUE,
+        inputId = "obtainable_info_range_button", justified = TRUE,
         choices = c("Obtainable info range"), checkIcon = list(yes = icon("less-than-equal"), no = icon("less-than-equal"))
       ),
 


### PR DESCRIPTION
## Description

- Fixed Shiny app where using the info range button without data loaded would crash the app.
- Updated CI settings to not include R 3.6 in buildtesting.
  - Buildtesting on R 3.6 is no longer possible because some dependencies now require R >= 4.0 and thus cannot be installed on R 3.6.
- Increased R version requirement to >= 4.0.