### PR TITLE
fix getInfoFixedTheta()

### DIFF
--- a/R/other_functions.R
+++ b/R/other_functions.R
@@ -187,33 +187,29 @@ getInfoFixedTheta <- function(
 ) {
 
   nj <- simulation_constants$nj
-  o <- list()
+  info_fixed_theta <- NULL
 
   if (!is.null(item_selection$fixed_theta)) {
     if (length(item_selection$fixed_theta) == 1) {
-      o$info_fixed_theta <- lapply(
+      info_fixed_theta <- lapply(
         seq_len(nj), function(j) {
           calc_info(item_selection$fixed_theta, item_pool@ipar, item_pool@NCAT, model)
         }
       )
-      o$select_at_fixed_theta <- TRUE
     }
     if (length(item_selection$fixed_theta) == nj) {
-      o$info_fixed_theta <- lapply(
+      info_fixed_theta <- lapply(
         seq_len(nj), function(j) {
           calc_info(item_selection$fixed_theta[j], item_pool@ipar, item_pool@NCAT, model)
         }
       )
-      o$select_at_fixed_theta <- TRUE
     }
-    if (is.null(o$info_fixed_theta)) {
+    if (is.null(info_fixed_theta)) {
       stop("config@item_selection: length($fixed_theta) must be either 1 or nj")
     }
-  } else {
-    o$select_at_fixed_theta <- FALSE
   }
 
-  return(o)
+  return(info_fixed_theta)
 
 }
 


### PR DESCRIPTION
## Description

- Fixed where using `FIXED` item selection method would result in the following error:
```
Error in info[eligibility_flag_in_current_theta_segment$i == 0] - simulation_constants$exposure_M : 
  non-numeric argument to binary operator
```
- This error was being caused by the information list being created in an unintended format.