### PR TITLE
update overlap control

### DIFF
--- a/R/plot_functions.R
+++ b/R/plot_functions.R
@@ -1012,8 +1012,9 @@ plotShadowOverlap <- function(x, color, color_stim, use_par, ...) {
 
   n_admins <- max(rowSums(cumulative_usage_matrix)) / test_length
 
-  if (n_admins < 2)
-    stop("plot(output_Shadow_all): at a minimum two administrations are needed")
+  if (n_admins < 2) {
+    stop("plot(output_Shadow_all): at a minimum two administrations are needed to plot overlap rates")
+  }
 
   n_used    <- rowSums(cumulative_usage_matrix > 0)
   n_times   <- sapply(1:n_admins, function(n) rowSums(cumulative_usage_matrix == n))

--- a/R/shadow_functions.R
+++ b/R/shadow_functions.R
@@ -484,6 +484,9 @@ setMethod(
     }
 
     # update cumulative usage matrix
+    if (is.null(cumulative_usage_matrix)) {
+      cumulative_usage_matrix <- usage_matrix * 0
+    }
     if (identical(dim(cumulative_usage_matrix), dim(usage_matrix))) {
       cumulative_usage_matrix <-
         cumulative_usage_matrix + usage_matrix

--- a/tests/testthat/test_overlap_control.r
+++ b/tests/testthat/test_overlap_control.r
@@ -1,0 +1,76 @@
+test_that("overlap control works", {
+
+  skip_on_cran()
+  skip_on_ci()
+
+  solver <- detectBestSolver()
+
+  # update constraints
+  constraints_science <- toggleConstraints(
+    constraints_science, off = c(14:20, 32:36)
+  )
+
+  # generate true theta
+  set.seed(1)
+  true_theta <- rnorm(100)
+
+  # simulation 1 ---------------------------------------------------------------
+
+  cfg_adaptive_1 <- createShadowTestConfig(
+    MIP = list(solver = solver),
+    refresh_policy = list(
+      method = "THRESHOLD"
+    ),
+    exposure_control = list(
+      method = "BIGM",
+      n_segment = 1,
+      segment_cut = c(-Inf, Inf)
+    )
+  )
+
+  adaptive_science_1 <- Shadow(
+    cfg_adaptive_1,
+    constraints_science,
+    true_theta = true_theta
+  )
+
+  expect_true(
+    all(rowSums(adaptive_science_1@cumulative_usage_matrix) == 30)
+  )
+
+  expect_error({
+    plot(adaptive_science_1, type = "overlap")
+  })
+
+  # simulation 2 ---------------------------------------------------------------
+
+  cfg_adaptive_2 <- createShadowTestConfig(
+    MIP = list(solver = solver),
+    refresh_policy = list(
+      method = "THRESHOLD"
+    ),
+    exposure_control = list(
+      method = "BIGM",
+      n_segment = 1,
+      segment_cut = c(-Inf, Inf),
+      initial_eligibility_stats = adaptive_science_1@eligibility_stats
+    ),
+    overlap_control = list(
+      method = "BIGM"
+    )
+  )
+
+  adaptive_science_2 <- Shadow(
+    cfg_adaptive_2,
+    constraints_science,
+    true_theta = true_theta,
+    cumulative_usage_matrix = adaptive_science_1@usage_matrix
+  )
+
+  expect_true(
+    all(rowSums(adaptive_science_2@cumulative_usage_matrix) == 60)
+  )
+
+  plot(adaptive_science_2, type = "overlap")
+
+})


### PR DESCRIPTION
## Description

- `Shadow()` now populates `cumulative_usage_matrix` in the first run as well.
  - This change is meant to allow the validation in `plot(type = "overlap")` to be able to detect whether the input is a first run.
- Added codetests for overlap control.