### PR TITLE
revert default solver to LPSOLVE

### DIFF
--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -20,23 +20,30 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: r-lib/actions/setup-pandoc@v2
-      - uses: r-lib/actions/setup-r@v2
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: install pandoc
+        uses: r-lib/actions/setup-pandoc@v2
+      - name: install R
+        uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
-      - uses: r-lib/actions/setup-r-dependencies@v2
+      - name: install dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: |
-            any::pkgdown
-            any::rlang
-            local::.
-            gurobi=?ignore
+          cache: false
+          extra-packages: any::pkgdown, any::rlang, gurobi=?ignore
           needs: website
-      - name: Build site
+      - name: install main package
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          cache: false
+          extra-packages: local::., gurobi=?ignore
+          needs: website
+      - name: build site
         run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
         shell: Rscript {0}
-      - name: Deploy to GitHub pages 🚀
+      - name: deploy to github pages
         if: github.event_name != 'pull_request'
         uses: JamesIves/github-pages-deploy-action@v4.5.0
         with:

--- a/R/shadow_class.R
+++ b/R/shadow_class.R
@@ -132,6 +132,13 @@ setClass("config_Shadow",
       }
     }
 
+    if (object@MIP$solver == "HIGHS") {
+      warning(sprintf(
+        "HIGHS solver is unstable as of 1.10.0.1 (installed version: %s) - it sometimes returns 0.5 as a solution for binary decision variables",
+        packageVersion("highs")
+      ))
+    }
+
     if (!toupper(object@item_selection$method) %in% c("MFI", "MPWI", "EB", "FB", "GFI", "FIXED", "RANDOM")) {
       msg <- sprintf("config@item_selection: unrecognized $method '%s' (accepts MFI, MPWI, EB, FB, GFI, FIXED or RANDOM)", object@item_selection$method)
       err <- c(err, msg)

--- a/R/shadow_class.R
+++ b/R/shadow_class.R
@@ -30,7 +30,7 @@ setClass("config_Shadow",
       method                    = "STA"
     ),
     MIP = list(
-      solver                    = "HIGHS",
+      solver                    = "LPSOLVE",
       verbosity                 = -2,
       time_limit                = 60,
       gap_limit                 = .05,
@@ -299,7 +299,7 @@ setClass("config_Shadow",
 #' }
 #' @param MIP a named list containing solver options.
 #' \itemize{
-#'   \item{\code{solver}} the type of solver. Accepts \code{Rsymphony, highs, gurobi, lpSolve, Rglpk}. (default = \code{HIGHS})
+#'   \item{\code{solver}} the type of solver. Accepts \code{Rsymphony, highs, gurobi, lpSolve, Rglpk}. (default = \code{LPSOLVE})
 #'   \item{\code{verbosity}} verbosity level of the solver. (default = \code{-2})
 #'   \item{\code{time_limit}} time limit in seconds. Used in solvers \code{Rsymphony, gurobi, Rglpk}. (default = \code{60})
 #'   \item{\code{gap_limit}} search termination criterion. Gap limit in relative scale passed onto the solver. Used in solver \code{gurobi}. (default = \code{.05})

--- a/R/solver_functions.R
+++ b/R/solver_functions.R
@@ -610,7 +610,7 @@ testSolver <- function(solver) {
 #' @export
 detectBestSolver <- function() {
   solver_list <- c(
-    "gurobi", "Rsymphony", "highs", "lpSolve"
+    "gurobi", "Rsymphony", "lpSolve"
   )
   for (solver in solver_list) {
     is_solver_available <- suppressWarnings(requireNamespace(solver, quietly = TRUE))

--- a/R/static_class.R
+++ b/R/static_class.R
@@ -17,7 +17,7 @@ setClass("config_Static",
       target_weight   = c(1, 1, 1)
     ),
     MIP = list(
-      solver          = "HIGHS",
+      solver          = "LPSOLVE",
       verbosity       = -2,
       time_limit      = 60,
       gap_limit       = 0.05,
@@ -92,7 +92,7 @@ setClass("config_Static",
 #'
 #' @param MIP a named list containing solver options.
 #' \itemize{
-#'   \item{\code{solver}} the type of solver. Accepts \code{Rsymphony, highs, gurobi, lpSolve, Rglpk}. (default = \code{HIGHS})
+#'   \item{\code{solver}} the type of solver. Accepts \code{Rsymphony, highs, gurobi, lpSolve, Rglpk}. (default = \code{LPSOLVE})
 #'   \item{\code{verbosity}} verbosity level of the solver. (default = \code{-2})
 #'   \item{\code{time_limit}} time limit in seconds. Used in solvers \code{Rsymphony, gurobi, Rglpk}. (default = \code{60})
 #'   \item{\code{gap_limit}} search termination criterion. Gap limit in relative scale passed onto the solver. Used in solver \code{gurobi}. (default = \code{.05})

--- a/R/static_class.R
+++ b/R/static_class.R
@@ -67,6 +67,12 @@ setClass("config_Static",
       msg <- sprintf("config@MIP: unrecognized $solver '%s' (accepts RSYMPHONY, HIGHS, GUROBI, LPSOLVE, or RGLPK)", object@MIP$solver)
       err <- c(err, msg)
     }
+    if (object@MIP$solver == "HIGHS") {
+      warning(sprintf(
+        "HIGHS solver is unstable as of 1.10.0.1 (installed version: %s) - it sometimes returns 0.5 as a solution for binary decision variables",
+        packageVersion("highs")
+      ))
+    }
 
     if (length(err) == 0) {
       return(TRUE)

--- a/man/createShadowTestConfig.Rd
+++ b/man/createShadowTestConfig.Rd
@@ -38,7 +38,7 @@ createShadowTestConfig(
 
 \item{MIP}{a named list containing solver options.
 \itemize{
-  \item{\code{solver}} the type of solver. Accepts \code{Rsymphony, highs, gurobi, lpSolve, Rglpk}. (default = \code{HIGHS})
+  \item{\code{solver}} the type of solver. Accepts \code{Rsymphony, highs, gurobi, lpSolve, Rglpk}. (default = \code{LPSOLVE})
   \item{\code{verbosity}} verbosity level of the solver. (default = \code{-2})
   \item{\code{time_limit}} time limit in seconds. Used in solvers \code{Rsymphony, gurobi, Rglpk}. (default = \code{60})
   \item{\code{gap_limit}} search termination criterion. Gap limit in relative scale passed onto the solver. Used in solver \code{gurobi}. (default = \code{.05})

--- a/man/createStaticTestConfig.Rd
+++ b/man/createStaticTestConfig.Rd
@@ -20,7 +20,7 @@ createStaticTestConfig(item_selection = NULL, MIP = NULL)
 
 \item{MIP}{a named list containing solver options.
 \itemize{
-  \item{\code{solver}} the type of solver. Accepts \code{Rsymphony, highs, gurobi, lpSolve, Rglpk}. (default = \code{HIGHS})
+  \item{\code{solver}} the type of solver. Accepts \code{Rsymphony, highs, gurobi, lpSolve, Rglpk}. (default = \code{LPSOLVE})
   \item{\code{verbosity}} verbosity level of the solver. (default = \code{-2})
   \item{\code{time_limit}} time limit in seconds. Used in solvers \code{Rsymphony, gurobi, Rglpk}. (default = \code{60})
   \item{\code{gap_limit}} search termination criterion. Gap limit in relative scale passed onto the solver. Used in solver \code{gurobi}. (default = \code{.05})


### PR DESCRIPTION
## Description

- HIGHS solver is unstable. It often gives 0.5 as a solution for binary decision variables.
- It was stable before in an old version; I think it became unstable at some point with version updates.
- Not easy to pinpoint a working version because installing older version requires HIGHS library (like how Rsymphony requires SYMPHONY library)
- Reverted the default solver to good old LPSOLVE